### PR TITLE
Refine command handling and portal persistence

### DIFF
--- a/src/main/java/eu/nurkert/porticlegun/PorticleGun.java
+++ b/src/main/java/eu/nurkert/porticlegun/PorticleGun.java
@@ -8,9 +8,9 @@ public final class PorticleGun extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        // Plugin startup logic
-        System.out.println("PorticleGun has been enabled!");
+        plugin = this;
 
+        getLogger().info("PorticleGun has been enabled!");
 
         PersitentHandler.getInstance();
         LoadingHandler.getInstance();
@@ -18,10 +18,6 @@ public final class PorticleGun extends JavaPlugin {
 
     public static boolean developMode = false;
     static PorticleGun plugin;
-
-    public PorticleGun() {
-        plugin = this;
-    }
 
     public static PorticleGun getInstance() {
         return plugin;

--- a/src/main/java/eu/nurkert/porticlegun/commands/PorticleGunCommand.java
+++ b/src/main/java/eu/nurkert/porticlegun/commands/PorticleGunCommand.java
@@ -18,9 +18,10 @@ import org.bukkit.inventory.Inventory;
 public class PorticleGunCommand implements CommandExecutor, Listener {
 
 
-    final private String TITLE = "§8PorticleGun";
+    private static final String TITLE = "§8PorticleGun";
+    private static final String COMMAND_PERMISSION = "porticlegun.command";
 
-    Inventory inv;
+    private final Inventory inv;
 
     public PorticleGunCommand() {
         inv = Bukkit.createInventory(null, InventoryType.DROPPER, TITLE);
@@ -28,31 +29,32 @@ public class PorticleGunCommand implements CommandExecutor, Listener {
     }
 
     private void init() {
-
-        for (int i = 0; i < inv.getSize(); i++)
+        for (int i = 0; i < inv.getSize(); i++) {
             inv.setItem(i, new ItemBuilder(Material.BLACK_STAINED_GLASS_PANE).setName("§0|").build());
+        }
         inv.setItem(4, ItemHandler.generateNewGun());
     }
 
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
-        if (sender instanceof Player) {
-            Player player = (Player) sender;
-
-            if (player.hasPermission("porticlegun.command")) {
-                player.openInventory(inv);
-                //SoundHandler.playSound(player, APGSound.INV_OPEN);
-            }
-
-        } else {
-            sender.sendMessage("You have no permission to execute this command.");
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Only players can execute this command.");
+            return true;
         }
+        Player player = (Player) sender;
+
+        if (!player.hasPermission(COMMAND_PERMISSION)) {
+            player.sendMessage("§cDu hast keine Berechtigung, diese Aktion auszuführen.");
+            return true;
+        }
+
+        player.openInventory(inv);
         return true;
     }
 
     @EventHandler
     public void on(InventoryClickEvent event) {
-        if (event.getView().getTitle().toString().equals(TITLE)) {
+        if (TITLE.equals(event.getView().getTitle())) {
             if (event.getRawSlot() < event.getInventory().getSize()) {
                 event.setCancelled(true);
                 if (event.getRawSlot() == 4) {
@@ -64,7 +66,7 @@ public class PorticleGunCommand implements CommandExecutor, Listener {
 
     @EventHandler
     public void on(InventoryCloseEvent event) {
-        if (event.getView().getTitle().toString().equals(TITLE)) {
+        if (TITLE.equals(event.getView().getTitle())) {
             //SoundHandler.playSound(event.getPlayer().getEyeLocation(), APGSound.INV_CLOSE);
         }
     }

--- a/src/main/java/eu/nurkert/porticlegun/handlers/PersitentHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/PersitentHandler.java
@@ -1,15 +1,15 @@
 package eu.nurkert.porticlegun.handlers;
 
 import eu.nurkert.porticlegun.PorticleGun;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.logging.Level;
 
 public class PersitentHandler {
     // Singleton construction
@@ -31,7 +31,11 @@ public class PersitentHandler {
     }
 
     public static List<String> getSection(String path) {
-        return new ArrayList<String>(config.getConfigurationSection(path).getKeys(false));
+        ConfigurationSection section = config.getConfigurationSection(path);
+        if (section == null) {
+            return new ArrayList<>();
+        }
+        return new ArrayList<>(section.getKeys(false));
     }
 
     public static void set(String path, Object value) {
@@ -39,12 +43,12 @@ public class PersitentHandler {
         portalsFile.save();
     }
 
-    public static String get(String path) {
+    public static String getString(String path) {
         return config.getString(path);
     }
 
     public static boolean exists(String path) {
-        return config.get(path) != null;
+        return config.contains(path);
     }
 
     public class PortalsFile {
@@ -87,7 +91,7 @@ public class PersitentHandler {
             try {
                 portals.save(portalYML);
             } catch (IOException e) {
-                e.printStackTrace();
+                PorticleGun.getInstance().getLogger().log(Level.SEVERE, "Failed to save portals.yml", e);
             }
         }
     }


### PR DESCRIPTION
## Summary
- ensure the plugin instance is initialised during `onEnable` and emit structured startup logging
- reuse a single `PorticleGunCommand` instance for registration, harden portal loading, and guard against missing command declarations
- make portal persistence safer by validating configuration access and logging save failures
- tighten portal gun ID handling and active portal bookkeeping to prevent stale links and invalid data

## Testing
- Not run (no automated tests were provided)

------
https://chatgpt.com/codex/tasks/task_e_68dce27d8fa08322bb0171c9149f4624