### PR TITLE
Optimize portal handling performance

### DIFF
--- a/src/main/java/eu/nurkert/porticlegun/handlers/visualization/PortalColor.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/visualization/PortalColor.java
@@ -3,6 +3,7 @@ package eu.nurkert.porticlegun.handlers.visualization;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
+import org.bukkit.Particle;
 
 public enum PortalColor {
     BLACK(ChatColor.BLACK, Color.BLACK, DyeColor.BLACK),
@@ -26,11 +27,13 @@ public enum PortalColor {
     Color bukkitColor;
 
     DyeColor dyeColor;
+    private final Particle.DustOptions dustOptions;
 
     PortalColor(ChatColor color, Color bukkitColor, DyeColor dyeColor) {
         this.color = color;
         this.bukkitColor = bukkitColor;
         this.dyeColor = dyeColor;
+        this.dustOptions = new Particle.DustOptions(bukkitColor, 1);
     }
 
     public ChatColor getChatColor() {
@@ -43,6 +46,10 @@ public enum PortalColor {
 
     public DyeColor getDyeColor() {
         return dyeColor;
+    }
+
+    public Particle.DustOptions getDustOptions() {
+        return dustOptions;
     }
 
     public PortalColor next() {

--- a/src/main/java/eu/nurkert/porticlegun/handlers/visualization/VisualizationHanlder.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/visualization/VisualizationHanlder.java
@@ -3,13 +3,15 @@ package eu.nurkert.porticlegun.handlers.visualization;
 import eu.nurkert.porticlegun.PorticleGun;
 import eu.nurkert.porticlegun.handlers.portals.ActivePortalsHandler;
 import eu.nurkert.porticlegun.portals.Portal;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.Particle;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
-import java.util.ArrayList;
+import java.util.Collection;
 
 public class VisualizationHanlder implements Listener {
 
@@ -23,22 +25,37 @@ public class VisualizationHanlder implements Listener {
 
             @Override
             public void run() {
-                ArrayList<Portal> portals = ActivePortalsHandler.getAllPortal();
-                for (int i = 0; i < portals.size(); i++) {
-                    Portal portal = portals.get(i);
-                    double radians = Math.toRadians(System.currentTimeMillis() / 5);
-                    Vector[] locs = {portal.getParticleLocation(radians) , portal.getParticleLocation(radians + Math.PI)};
-                    Color color = GunColorHandler.getColors(portal.getGunID()).get(portal.getType()).getBukkitColor();
-                    for(Player player : Bukkit.getOnlinePlayers()) {
-                        Particle.DustOptions dustOptions = new Particle.DustOptions(color, 1);
-                        for(Vector loc : locs) {
-                            player.spawnParticle(Particle.REDSTONE, loc.getX(), loc.getY(), loc.getZ(), 1, dustOptions);
-                        }
-                        //player.getWorld().spawnParticle(Particle.NOTE, player.getLocation(), 1, null);
+                Collection<Portal> portals = ActivePortalsHandler.getAllPortals();
+                if (portals.isEmpty()) {
+                    return;
+                }
 
+                Collection<? extends Player> players = Bukkit.getOnlinePlayers();
+                if (players.isEmpty()) {
+                    return;
+                }
 
+                double radians = Math.toRadians(System.currentTimeMillis() * 0.2d);
+
+                for (Portal portal : portals) {
+                    Vector first = portal.getParticleLocation(radians);
+                    Vector second = portal.getParticleLocation(radians + Math.PI);
+                    if (first == null || second == null) {
+                        continue;
                     }
 
+                    GunColors gunColors = GunColorHandler.getColors(portal.getGunID());
+                    PortalColor portalColor = gunColors.get(portal.getType());
+                    Particle.DustOptions dustOptions = portalColor.getDustOptions();
+
+                    World portalWorld = portal.getLocation().getWorld();
+                    for (Player player : players) {
+                        if (portalWorld != null && !player.getWorld().equals(portalWorld)) {
+                            continue;
+                        }
+                        player.spawnParticle(Particle.REDSTONE, first.getX(), first.getY(), first.getZ(), 1, dustOptions);
+                        player.spawnParticle(Particle.REDSTONE, second.getX(), second.getY(), second.getZ(), 1, dustOptions);
+                    }
                 }
             }
         }.runTaskTimer(PorticleGun.getInstance(), 0, 1);


### PR DESCRIPTION
## Summary
- cache active portals to avoid per-tick list reconstruction and filter lookups by world
- streamline teleportation lookups and remove unused code while keeping velocity transfer
- reduce particle spawning overhead via cached dust options and reuse of gun color data
- optimize gun ID translation by using precomputed character maps

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dce7aa9750832283a6f17d556bd1a3