### PR TITLE
Preserve momentum and view direction through portals

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@
 ![Alt text](https://raw.githubusercontent.com/nurkert/PorticleGun/main/images/crafting_recipe.png)
 
 For even more information please visit the [plugin page](https://www.spigotmc.org/resources/porticlegun-1-9.107796/).
+
+## Recent Changes
+
+* **Portal physics** – Entities now keep their full momentum and facing when travelling between linked portals. Movement vectors are rotated into the destination portal's frame so that Portal-style conservation of velocity and view direction is preserved after teleportation.

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
         </plugins>
         <resources>
             <resource>
@@ -59,6 +67,10 @@
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -68,5 +80,19 @@
             <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.seeseemelk</groupId>
+            <artifactId>MockBukkit-v1.20</artifactId>
+            <version>3.7.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    
 </project>

--- a/src/main/java/eu/nurkert/porticlegun/handlers/portals/TeleportationHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/portals/TeleportationHandler.java
@@ -21,17 +21,71 @@ public class TeleportationHandler implements Listener {
             for (Portal portal : portals) {
                 if (portal.isInPortal(event.getTo()) || (portal.getDirection().getY() == -1.0 && portal.isInPortal(event.getTo().clone().add(0, 1, 0)))) {
                     if(portal.getLinkedPortal() != null) {
-                        Location destination = portal.getLinkedPortal().getLocation().clone().add(0.5, portal.getLinkedPortal().getDirection().getY() == -1.0 ? -1 : 0, 0.5);
-                        destination.setDirection(portal.getLinkedPortal().getDirection());
-                        Vector velocity = player.getVelocity();
+                        Vector preTeleportVelocity = player.getVelocity().clone();
+                        Vector preTeleportLook = player.getLocation().getDirection().clone();
+
+                        Portal linkedPortal = portal.getLinkedPortal();
+
+                        PortalBasis sourceBasis = createPortalBasis(portal.getDirection());
+                        PortalBasis destinationBasis = createPortalBasis(linkedPortal.getDirection());
+
+                        Vector transformedVelocity = transformVector(preTeleportVelocity, sourceBasis, destinationBasis);
+                        Vector transformedLook = transformVector(preTeleportLook, sourceBasis, destinationBasis).normalize();
+
+                        Location destination = linkedPortal.getLocation().clone().add(0.5, linkedPortal.getDirection().getY() == -1.0 ? -1 : 0, 0.5);
+                        destination.setDirection(transformedLook);
+
                         player.teleport(destination);
-                        player.setVelocity(destination.getDirection().multiply(velocity.length()));
+                        player.setVelocity(transformedVelocity);
                         break;
                     }
                 }
             }
         }
 
+    }
+
+    static PortalBasis createPortalBasis(Vector direction) {
+        Vector forward = direction.clone();
+        if (forward.lengthSquared() == 0) {
+            forward = new Vector(0, 0, 1);
+        }
+        forward.normalize();
+
+        Vector auxiliaryAxis = Math.abs(forward.getY()) > 0.999 ? new Vector(0, 0, 1) : new Vector(0, 1, 0);
+        Vector right = forward.clone().crossProduct(auxiliaryAxis);
+        if (right.lengthSquared() == 0) {
+            auxiliaryAxis = new Vector(1, 0, 0);
+            right = forward.clone().crossProduct(auxiliaryAxis);
+        }
+        right.normalize();
+
+        Vector up = right.clone().crossProduct(forward).normalize();
+
+        return new PortalBasis(forward, up, right);
+    }
+
+    static Vector transformVector(Vector vector, PortalBasis source, PortalBasis destination) {
+        double forwardComponent = vector.dot(source.forward);
+        double upComponent = vector.dot(source.up);
+        double rightComponent = vector.dot(source.right);
+
+        Vector transformed = destination.forward.clone().multiply(forwardComponent);
+        transformed.add(destination.up.clone().multiply(upComponent));
+        transformed.add(destination.right.clone().multiply(rightComponent));
+        return transformed;
+    }
+
+    static class PortalBasis {
+        final Vector forward;
+        final Vector up;
+        final Vector right;
+
+        PortalBasis(Vector forward, Vector up, Vector right) {
+            this.forward = forward;
+            this.up = up;
+            this.right = right;
+        }
     }
 
     double[][] expected = {

--- a/src/test/java/eu/nurkert/porticlegun/handlers/portals/TeleportationHandlerTest.java
+++ b/src/test/java/eu/nurkert/porticlegun/handlers/portals/TeleportationHandlerTest.java
@@ -1,0 +1,123 @@
+package eu.nurkert.porticlegun.handlers.portals;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.WorldMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import eu.nurkert.porticlegun.handlers.visualization.concrete.PortalVisualizationType;
+import eu.nurkert.porticlegun.portals.Portal;
+import org.bukkit.Location;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.util.Vector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TeleportationHandlerTest {
+
+    private ServerMock server;
+    private WorldMock world;
+    private TeleportationHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        world = server.addSimpleWorld("world");
+        handler = new TeleportationHandler();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void preservesMomentumAcrossPerpendicularWallPortals() {
+        Portal source = new Portal(new Location(world, 0, 64, 0), new Vector(0, 0, 1), "gun", Portal.PortalType.PRIMARY, PortalVisualizationType.RECTANGULAR);
+        Portal destinationPortal = new Portal(new Location(world, 10, 64, 0), new Vector(1, 0, 0), "gun", Portal.PortalType.SECONDARY, PortalVisualizationType.RECTANGULAR);
+        ActivePortalsHandler.setPrimaryPortal("gun", source);
+        ActivePortalsHandler.setSecondaryPortal("gun", destinationPortal);
+
+        PlayerMock player = server.addPlayer();
+
+        Vector initialVelocity = new Vector(0.4, 0.6, 0.8);
+        Vector initialLook = new Vector(0.2, 0.4, 0.9);
+
+        Location startingLocation = new Location(world, -1, 64, 0.5);
+        startingLocation.setDirection(initialLook);
+        player.teleport(startingLocation);
+        player.setVelocity(initialVelocity);
+
+        Location destinationLocation = new Location(world, 0.5, 64, 0.5);
+        destinationLocation.setDirection(initialLook);
+        PlayerMoveEvent event = new PlayerMoveEvent(player, startingLocation, destinationLocation);
+
+        Vector expectedVelocity = new Vector(0.8, 0.6, -0.4);
+        Vector expectedLook = new Vector(0.9, 0.4, -0.2).normalize();
+        float expectedYaw = computeYaw(expectedLook);
+        float expectedPitch = computePitch(expectedLook);
+
+        handler.on(event);
+
+        assertVectorEquals(expectedVelocity, player.getVelocity());
+        assertVectorEquals(expectedLook, player.getLocation().getDirection());
+        assertEquals(expectedYaw, player.getLocation().getYaw(), 1.0e-4);
+        assertEquals(expectedPitch, player.getLocation().getPitch(), 1.0e-4);
+
+        ActivePortalsHandler.removePrimaryPortal("gun");
+        ActivePortalsHandler.removeSecondaryPortal("gun");
+    }
+
+    @Test
+    void preservesMomentumAcrossFloorToWallPortal() {
+        Portal source = new Portal(new Location(world, 5, 63, 5), new Vector(0, 1, 0), "gun2", Portal.PortalType.PRIMARY, PortalVisualizationType.RECTANGULAR);
+        Portal destinationPortal = new Portal(new Location(world, 5, 70, 15), new Vector(0, 0, 1), "gun2", Portal.PortalType.SECONDARY, PortalVisualizationType.RECTANGULAR);
+        ActivePortalsHandler.setPrimaryPortal("gun2", source);
+        ActivePortalsHandler.setSecondaryPortal("gun2", destinationPortal);
+
+        PlayerMock player = server.addPlayer();
+
+        Vector initialVelocity = new Vector(0.3, 1.2, -0.5);
+        Vector initialLook = new Vector(0.2, 1.0, -0.3);
+
+        Location startingLocation = new Location(world, 5.5, 62, 5.5);
+        startingLocation.setDirection(initialLook);
+        player.teleport(startingLocation);
+        player.setVelocity(initialVelocity);
+
+        Location destinationLocation = new Location(world, 5.5, 63, 5.5);
+        destinationLocation.setDirection(initialLook);
+        PlayerMoveEvent event = new PlayerMoveEvent(player, startingLocation, destinationLocation);
+
+        Vector expectedVelocity = new Vector(-0.3, -0.5, 1.2);
+        Vector expectedLook = new Vector(-0.2, -0.3, 1.0).normalize();
+        float expectedYaw = computeYaw(expectedLook);
+        float expectedPitch = computePitch(expectedLook);
+
+        handler.on(event);
+
+        assertVectorEquals(expectedVelocity, player.getVelocity());
+        assertVectorEquals(expectedLook, player.getLocation().getDirection());
+        assertEquals(expectedYaw, player.getLocation().getYaw(), 1.0e-4);
+        assertEquals(expectedPitch, player.getLocation().getPitch(), 1.0e-4);
+
+        ActivePortalsHandler.removePrimaryPortal("gun2");
+        ActivePortalsHandler.removeSecondaryPortal("gun2");
+    }
+
+    private void assertVectorEquals(Vector expected, Vector actual) {
+        assertEquals(expected.getX(), actual.getX(), 1.0e-6);
+        assertEquals(expected.getY(), actual.getY(), 1.0e-6);
+        assertEquals(expected.getZ(), actual.getZ(), 1.0e-6);
+    }
+
+    private float computeYaw(Vector direction) {
+        return (float) Math.toDegrees(Math.atan2(-direction.getX(), direction.getZ()));
+    }
+
+    private float computePitch(Vector direction) {
+        return (float) Math.toDegrees(Math.asin(-direction.getY()));
+    }
+}


### PR DESCRIPTION
## Summary
- preserve player velocity and facing across portals by transforming vectors into the destination basis
- expose reusable basis/transform utilities and add MockBukkit regression tests for wall and floor portal pairs
- wire up JUnit/MockBukkit dependencies and document the conserved-momentum behaviour for server owners

## Testing
- `mvn test` *(fails: existing project compilation errors referencing missing handlers and outdated Bukkit particle constants)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf44e54d0832297496c68a2cba1c2