### PR TITLE
Add administrative management commands for portal guns

### DIFF
--- a/src/main/java/eu/nurkert/porticlegun/commands/PorticleGunCommand.java
+++ b/src/main/java/eu/nurkert/porticlegun/commands/PorticleGunCommand.java
@@ -1,12 +1,18 @@
 package eu.nurkert.porticlegun.commands;
 
+import eu.nurkert.porticlegun.PorticleGun;
 import eu.nurkert.porticlegun.builders.ItemBuilder;
+import eu.nurkert.porticlegun.handlers.LoadingHandler;
+import eu.nurkert.porticlegun.handlers.PersitentHandler;
 import eu.nurkert.porticlegun.handlers.item.ItemHandler;
+import eu.nurkert.porticlegun.handlers.portals.ActivePortalsHandler;
+import eu.nurkert.porticlegun.portals.Portal;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -14,11 +20,24 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
 
-public class PorticleGunCommand implements CommandExecutor, Listener {
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class PorticleGunCommand implements CommandExecutor, Listener, TabCompleter {
 
 
-    final private String TITLE = "§8PorticleGun";
+    private static final String TITLE = "§8PorticleGun";
+    private static final String COMMAND_PERMISSION = "porticlegun.command";
+    private static final String ADMIN_PERMISSION = "porticlegun.admin";
 
     Inventory inv;
 
@@ -36,18 +55,252 @@ public class PorticleGunCommand implements CommandExecutor, Listener {
 
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
-        if (sender instanceof Player) {
-            Player player = (Player) sender;
+        if (args.length == 0) {
+            if (sender instanceof Player) {
+                Player player = (Player) sender;
 
-            if (player.hasPermission("porticlegun.command")) {
-                player.openInventory(inv);
-                //SoundHandler.playSound(player, APGSound.INV_OPEN);
+                if (player.hasPermission(COMMAND_PERMISSION)) {
+                    player.openInventory(inv);
+                    //SoundHandler.playSound(player, APGSound.INV_OPEN);
+                } else {
+                    player.sendMessage("§cYou do not have permission to use this command.");
+                }
+            } else {
+                sender.sendMessage("§cOnly players may open the PorticleGun menu.");
             }
-
-        } else {
-            sender.sendMessage("You have no permission to execute this command.");
+            return true;
         }
-        return true;
+
+        String subCommand = args[0].toLowerCase(Locale.ROOT);
+        switch (subCommand) {
+            case "list":
+                if (!ensureAdmin(sender)) return true;
+                handleList(sender);
+                return true;
+            case "remove":
+                if (!ensureAdmin(sender)) return true;
+                if (args.length < 2) {
+                    sender.sendMessage("§cUsage: /" + label + " remove <gunId>");
+                    return true;
+                }
+                handleRemove(sender, args[1]);
+                return true;
+            case "clearplayer":
+                if (!ensureAdmin(sender)) return true;
+                if (args.length < 2) {
+                    sender.sendMessage("§cUsage: /" + label + " clearplayer <player>");
+                    return true;
+                }
+                handleClearPlayer(sender, args[1]);
+                return true;
+            case "reload":
+                if (!ensureAdmin(sender)) return true;
+                handleReload(sender);
+                return true;
+            default:
+                sender.sendMessage("§cUnknown subcommand. Available: list, remove, clearplayer, reload");
+                return true;
+        }
+    }
+
+    private boolean ensureAdmin(CommandSender sender) {
+        if (!(sender instanceof Player)) {
+            return true;
+        }
+        if (((Player) sender).hasPermission(ADMIN_PERMISSION)) {
+            return true;
+        }
+        sender.sendMessage("§cYou do not have permission to manage PorticleGun data.");
+        return false;
+    }
+
+    private void handleList(CommandSender sender) {
+        if (!PersitentHandler.exists("porticleguns")) {
+            sender.sendMessage("§eNo stored portal guns found.");
+            return;
+        }
+
+        List<String> entries = PersitentHandler.getSection("porticleguns");
+        if (entries.isEmpty()) {
+            sender.sendMessage("§eNo stored portal guns found.");
+            return;
+        }
+
+        sender.sendMessage("§aStored portal guns (" + entries.size() + "):");
+        for (String entry : entries) {
+            String gunId = ItemHandler.useable(entry);
+            String basePath = "porticleguns." + entry;
+            boolean persistedPrimary = PersitentHandler.exists(basePath + ".primary.position");
+            boolean persistedSecondary = PersitentHandler.exists(basePath + ".secondary.position");
+            boolean activePrimary = ActivePortalsHandler.hasPrimaryPortal(gunId);
+            boolean activeSecondary = ActivePortalsHandler.hasSecondaryPortal(gunId);
+
+            String primaryStatus = buildStatus(activePrimary, persistedPrimary);
+            String secondaryStatus = buildStatus(activeSecondary, persistedSecondary);
+
+            sender.sendMessage("§7- §f" + gunId + " §8[§9primary: " + primaryStatus + "§8, §dsecondary: " + secondaryStatus + "§8]");
+        }
+    }
+
+    private String buildStatus(boolean active, boolean persisted) {
+        if (active) {
+            return "§aactive";
+        }
+        if (persisted) {
+            return "§esaved";
+        }
+        return "§cnone";
+    }
+
+    private void handleRemove(CommandSender sender, String gunId) {
+        if (!ItemHandler.isValidGunID(gunId)) {
+            sender.sendMessage("§c'" + gunId + "' is not a valid PorticleGun ID.");
+            return;
+        }
+
+        if (removeGunData(gunId)) {
+            sender.sendMessage("§aRemoved stored data for gun §f" + gunId + "§a.");
+        } else {
+            sender.sendMessage("§eNo stored portals were found for gun §f" + gunId + "§e.");
+        }
+    }
+
+    private void handleClearPlayer(CommandSender sender, String playerName) {
+        Player target = Bukkit.getPlayerExact(playerName);
+        if (target == null) {
+            sender.sendMessage("§cPlayer '" + playerName + "' is not online.");
+            return;
+        }
+
+        Set<String> gunIds = collectGunIds(target);
+        if (gunIds.isEmpty()) {
+            sender.sendMessage("§ePlayer §f" + target.getName() + " §ehas no PorticleGuns in their inventories.");
+            return;
+        }
+
+        List<String> cleared = new ArrayList<>();
+        List<String> untouched = new ArrayList<>();
+
+        for (String gunId : gunIds) {
+            if (removeGunData(gunId)) {
+                cleared.add(gunId);
+            } else {
+                untouched.add(gunId);
+            }
+        }
+
+        if (!cleared.isEmpty()) {
+            sender.sendMessage("§aCleared portals for §f" + target.getName() + "§a: §7" + String.join("§8, §7", cleared));
+        }
+
+        if (!untouched.isEmpty()) {
+            sender.sendMessage("§eNo stored portals found for: §7" + String.join("§8, §7", untouched));
+        }
+
+        if (cleared.isEmpty() && untouched.isEmpty()) {
+            sender.sendMessage("§eNo portal data was changed for §f" + target.getName() + "§e.");
+        }
+    }
+
+    private Set<String> collectGunIds(Player player) {
+        Set<String> ids = new HashSet<>();
+        PlayerInventory inventory = player.getInventory();
+        collectFromItems(ids, inventory.getContents());
+        collectFromItems(ids, inventory.getArmorContents());
+        collectFromItems(ids, inventory.getExtraContents());
+        collectFromItem(ids, inventory.getItemInOffHand());
+        collectFromItems(ids, player.getEnderChest().getContents());
+        return ids;
+    }
+
+    private void collectFromItems(Set<String> ids, ItemStack[] items) {
+        if (items == null) {
+            return;
+        }
+        for (ItemStack item : items) {
+            collectFromItem(ids, item);
+        }
+    }
+
+    private void collectFromItem(Set<String> ids, ItemStack item) {
+        String gunId = ItemHandler.isValidGun(item);
+        if (gunId != null) {
+            ids.add(gunId);
+        }
+    }
+
+    private boolean removeGunData(String gunId) {
+        boolean modified = false;
+
+        Portal primary = ActivePortalsHandler.getPrimaryPortal(gunId);
+        if (primary != null) {
+            primary.delete();
+            ActivePortalsHandler.removePrimaryPortal(gunId);
+            modified = true;
+        }
+
+        Portal secondary = ActivePortalsHandler.getSecondaryPortal(gunId);
+        if (secondary != null) {
+            secondary.delete();
+            ActivePortalsHandler.removeSecondaryPortal(gunId);
+            modified = true;
+        }
+
+        String encodedId = ItemHandler.saveable(gunId);
+        if (PersitentHandler.exists("porticleguns." + encodedId)) {
+            PersitentHandler.set("porticleguns." + encodedId, null);
+            PersitentHandler.saveAll();
+            modified = true;
+        }
+
+        return modified;
+    }
+
+    private void handleReload(CommandSender sender) {
+        PorticleGun.getInstance().reloadConfig();
+        LoadingHandler.getInstance().reload();
+        sender.sendMessage("§aPorticleGun data reloaded from disk.");
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1) {
+            if (!hasAdminSuggestions(sender)) {
+                return Collections.emptyList();
+            }
+            List<String> options = Arrays.asList("list", "remove", "clearplayer", "reload");
+            String prefix = args[0].toLowerCase(Locale.ROOT);
+            return options.stream()
+                    .filter(option -> option.startsWith(prefix))
+                    .collect(Collectors.toList());
+        }
+
+        if (args.length == 2 && hasAdminSuggestions(sender)) {
+            String sub = args[0].toLowerCase(Locale.ROOT);
+            if (sub.equals("remove")) {
+                if (!PersitentHandler.exists("porticleguns")) {
+                    return Collections.emptyList();
+                }
+                String prefix = args[1].toLowerCase(Locale.ROOT);
+                return PersitentHandler.getSection("porticleguns").stream()
+                        .map(ItemHandler::useable)
+                        .filter(id -> id.toLowerCase(Locale.ROOT).startsWith(prefix))
+                        .collect(Collectors.toList());
+            }
+            if (sub.equals("clearplayer")) {
+                String prefix = args[1].toLowerCase(Locale.ROOT);
+                return Bukkit.getOnlinePlayers().stream()
+                        .map(Player::getName)
+                        .filter(name -> name.toLowerCase(Locale.ROOT).startsWith(prefix))
+                        .collect(Collectors.toList());
+            }
+        }
+
+        return Collections.emptyList();
+    }
+
+    private boolean hasAdminSuggestions(CommandSender sender) {
+        return !(sender instanceof Player) || ((Player) sender).hasPermission(ADMIN_PERMISSION);
     }
 
     @EventHandler

--- a/src/main/java/eu/nurkert/porticlegun/handlers/LoadingHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/LoadingHandler.java
@@ -10,6 +10,8 @@ import eu.nurkert.porticlegun.handlers.visualization.*;
 import eu.nurkert.porticlegun.portals.Portal;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.event.Listener;
 
 import java.util.Base64;
@@ -21,8 +23,11 @@ public class LoadingHandler {
     // Singleton construction
     final private static LoadingHandler instance = new LoadingHandler();
 
+    private final PorticleGunCommand porticleGunCommand;
+
     private LoadingHandler() {
         // Private constructor
+        porticleGunCommand = new PorticleGunCommand();
         registerEvents();
         registerCommands();
         loadPortals();
@@ -40,7 +45,7 @@ public class LoadingHandler {
         register(new RecipeHandler());
         register(new PortalOpenHandler());
         register(new ActivePortalsHandler());
-        register(new PorticleGunCommand());
+        register(porticleGunCommand);
         register(new VisualizationHanlder());
         register(new TeleportationHandler());
         register(new ChangeColorHandler());
@@ -55,7 +60,7 @@ public class LoadingHandler {
     }
 
     private void registerCommands() {
-        register(new PorticleGunCommand(), "porticlegun");
+        register(porticleGunCommand, "porticlegun");
     }
 
     /**
@@ -65,7 +70,14 @@ public class LoadingHandler {
      * @param command  The command to register the executor to
      */
     private void register(CommandExecutor executor, String command) {
-        PorticleGun.getInstance().getCommand(command).setExecutor(executor);
+        PluginCommand pluginCommand = PorticleGun.getInstance().getCommand(command);
+        if (pluginCommand == null) {
+            return;
+        }
+        pluginCommand.setExecutor(executor);
+        if (executor instanceof TabCompleter) {
+            pluginCommand.setTabCompleter((TabCompleter) executor);
+        }
     }
 
     /**
@@ -103,5 +115,12 @@ public class LoadingHandler {
                 }
             });
         }
+    }
+
+    public void reload() {
+        PersitentHandler.reload();
+        ActivePortalsHandler.clear();
+        GunColorHandler.clear();
+        loadPortals();
     }
 }

--- a/src/main/java/eu/nurkert/porticlegun/handlers/PersitentHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/PersitentHandler.java
@@ -31,7 +31,10 @@ public class PersitentHandler {
     }
 
     public static List<String> getSection(String path) {
-        return new ArrayList<String>(config.getConfigurationSection(path).getKeys(false));
+        if (config.getConfigurationSection(path) == null) {
+            return new ArrayList<>();
+        }
+        return new ArrayList<>(config.getConfigurationSection(path).getKeys(false));
     }
 
     public static void set(String path, Object value) {
@@ -45,6 +48,15 @@ public class PersitentHandler {
 
     public static boolean exists(String path) {
         return config.get(path) != null;
+    }
+
+    public static void saveAll() {
+        portalsFile.save();
+    }
+
+    public static void reload() {
+        portalsFile.reload();
+        config = portalsFile.getConfig();
     }
 
     public class PortalsFile {
@@ -89,6 +101,10 @@ public class PersitentHandler {
             } catch (IOException e) {
                 e.printStackTrace();
             }
+        }
+
+        public void reload() {
+            portals = YamlConfiguration.loadConfiguration(portalYML);
         }
     }
 }

--- a/src/main/java/eu/nurkert/porticlegun/handlers/portals/ActivePortalsHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/portals/ActivePortalsHandler.java
@@ -59,6 +59,11 @@ public class ActivePortalsHandler implements Listener {
         }};
     }
 
+    public static void clear() {
+        primaryPortals.clear();
+        secondaryPortals.clear();
+    }
+
     /**
      * @param player the player to get the portals for
      * @return all portals that are relevant to the player

--- a/src/main/java/eu/nurkert/porticlegun/handlers/visualization/GunColorHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/visualization/GunColorHandler.java
@@ -53,5 +53,9 @@ public class GunColorHandler {
         getColors(gunID).selectPreviousSecondary(gunID);
     }
 
+    public static void clear() {
+        colors.clear();
+    }
+
 
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,15 @@ authors: [ nurkert ]
 
 commands:
   porticlegun:
-    description: Get a PorticleGun
-    usage: /porticlegun
+    description: Manage or obtain a PorticleGun
+    usage: /<command> [list|remove <id>|clearplayer <player>|reload]
     permission: porticlegun.command
+    tab-completer: eu.nurkert.porticlegun.commands.PorticleGunCommand
+
+permissions:
+  porticlegun.command:
+    description: Allows using /porticlegun to obtain a gun
+    default: true
+  porticlegun.admin:
+    description: Allows administrative PorticleGun management commands
+    default: op


### PR DESCRIPTION
## Summary
- add administrative subcommands to `/porticlegun` for listing, removing, clearing, and reloading portal data with permission checks
- wire the shared command instance for tab completion and expose new admin permission in `plugin.yml`
- extend persistence utilities to support safe reloads and clearing of cached portal state

## Testing
- mvn -DskipTests package *(fails: missing ChangeColorHandler class and outdated portal/particle references in existing sources)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf43fb3208322b9f3965b99702c6f