### PR TITLE
Add JitPack repository to resolve MockBukkit dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,10 @@
             <id>papermc</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
## Summary
- add the JitPack repository to the Maven configuration so MockBukkit can be resolved during IntelliJ builds

## Testing
- mvn -e -DskipTests=false test *(fails: MockBukkit initialization due to Spigot 1.21 registry changes)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf9caeba4832288ed3327008a0127