### PR TITLE
Add localization support and message manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,23 @@ The plugin ships with a `config.yml` that can be used to tweak runtime behaviour
 
 * `gravity-gun.enabled` – Set to `false` to completely disable the gravity gun event listeners and background tasks.
 * `gravity-gun.block-blacklist` – A list of Bukkit material names that players are prevented from picking up with the gravity gun.
+
+## Localization
+
+Player-facing text is stored in `messages.yml`. The file is copied to the plugin's data folder on first start, so you can adjust translations without rebuilding the plugin.
+
+### Editing translations
+
+* `default-language` controls which language section is used as the fallback and for console output. Change it to the language key you prefer (for example `de`).
+* Each top-level language key (`en`, `de`, …) mirrors the same nested structure. Add new sections or edit the existing strings to customise the wording. Colour codes use the standard `&` notation and support placeholders such as `%gun_id%`, `%player%`, or `%state%`.
+* After modifying the file, run `/porticlegun reload` to apply the new texts in-game.
+
+### Per-player language selection
+
+The plugin automatically tries to match a player's Minecraft locale (e.g. `de_de` or `en_us`) to the available language sections. If a match is found, that translation is used for menu titles, chat messages, and other UI elements for that player. Operators can also override the language manually at runtime:
+
+```java
+MessageManager.setPlayerLanguage(player.getUniqueId(), "de");
+```
+
+Calling the method with `null` reverts a player back to automatic detection. This makes it easy to integrate custom language selectors or to honour preferences stored by other plugins.

--- a/src/main/java/eu/nurkert/porticlegun/PorticleGun.java
+++ b/src/main/java/eu/nurkert/porticlegun/PorticleGun.java
@@ -3,6 +3,7 @@ package eu.nurkert.porticlegun;
 import eu.nurkert.porticlegun.config.ConfigManager;
 import eu.nurkert.porticlegun.handlers.LoadingHandler;
 import eu.nurkert.porticlegun.handlers.PersitentHandler;
+import eu.nurkert.porticlegun.messages.MessageManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class PorticleGun extends JavaPlugin {
@@ -16,6 +17,7 @@ public final class PorticleGun extends JavaPlugin {
         saveDefaultConfig();
         ConfigManager.init();
         PersitentHandler.getInstance();
+        MessageManager.init(this);
         LoadingHandler.getInstance();
     }
 

--- a/src/main/java/eu/nurkert/porticlegun/handlers/LoadingHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/LoadingHandler.java
@@ -10,6 +10,7 @@ import eu.nurkert.porticlegun.handlers.portals.*;
 import eu.nurkert.porticlegun.handlers.visualization.*;
 import eu.nurkert.porticlegun.handlers.visualization.concrete.PortalVisualizationType;
 import eu.nurkert.porticlegun.portals.Portal;
+import eu.nurkert.porticlegun.messages.MessageManager;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.PluginCommand;
@@ -137,6 +138,8 @@ public class LoadingHandler {
     }
 
     public void reload() {
+        MessageManager.reload(PorticleGun.getInstance());
+        porticleGunCommand.reloadMessages();
         ConfigManager.reload();
         updateGravityGunRegistration();
         PersitentHandler.reload();

--- a/src/main/java/eu/nurkert/porticlegun/handlers/item/ItemHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/item/ItemHandler.java
@@ -1,6 +1,7 @@
 package eu.nurkert.porticlegun.handlers.item;
 
 import eu.nurkert.porticlegun.builders.ItemBuilder;
+import eu.nurkert.porticlegun.messages.MessageManager;
 import org.bukkit.Material;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
@@ -9,11 +10,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 import java.util.Random;
 
 public class ItemHandler implements Listener {
-
-    // uniform name for the PorticleGun
-    public static final String PORTICLE_GUN_NAME = "§5PorticleGun";
-    // uniform description lore for the PorticleGun
-    public static final String PORTICLE_GUN_LORE = "§7Device that creates portals.";
 
     // uniform type for the PorticleGun
     public static final Material PORTICLE_GUN_TYPE = Material.BREWING_STAND;
@@ -27,10 +23,14 @@ public class ItemHandler implements Listener {
         String id = generateGunID();
 
         ItemBuilder builder = new ItemBuilder(PORTICLE_GUN_TYPE);
-        builder.setName(PORTICLE_GUN_NAME);
-        builder.setLore(vanishID(id), PORTICLE_GUN_LORE);
+        builder.setName(getPorticleGunName());
+        builder.setLore(vanishID(id), MessageManager.getMessage("items.porticlegun.lore"));
 
         return builder.build();
+    }
+
+    public static String getPorticleGunName() {
+        return MessageManager.getMessage("items.porticlegun.name");
     }
 
     /**

--- a/src/main/java/eu/nurkert/porticlegun/handlers/item/RecipeHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/item/RecipeHandler.java
@@ -36,7 +36,7 @@ public class RecipeHandler implements Listener {
     public void on(CraftItemEvent event) {
         ItemStack crafted = event.getCurrentItem();
         if (crafted.getType() == Material.BREWING_STAND && crafted.hasItemMeta() &&
-                crafted.getItemMeta().getDisplayName().equals(ItemHandler.PORTICLE_GUN_NAME)) {
+                crafted.getItemMeta().getDisplayName().equals(ItemHandler.getPorticleGunName())) {
             // so not ever portal has the same id
             event.setCurrentItem(ItemHandler.generateNewGun());
         }

--- a/src/main/java/eu/nurkert/porticlegun/handlers/visualization/PortalCreationAnimation.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/visualization/PortalCreationAnimation.java
@@ -23,11 +23,11 @@ public final class PortalCreationAnimation {
             return;
         }
 
-        Location center = computePortalCenter(portal);
+        final Location center = computePortalCenter(portal);
         if (center == null) {
             return;
         }
-        World world = center.getWorld();
+        final World world = center.getWorld();
         if (world == null) {
             return;
         }
@@ -49,6 +49,13 @@ public final class PortalCreationAnimation {
         double maxUp = portal.getDirection().getY() == 0.0 ? 0.95 : 0.55;
         int pointsPerTick = 36;
 
+        final Vector finalRight = right.clone();
+        final Vector finalUp = up.clone();
+        final Particle.DustOptions finalDustOptions = dustOptions;
+        final double finalMaxRight = maxRight;
+        final double finalMaxUp = maxUp;
+        final int finalPointsPerTick = pointsPerTick;
+
         new BukkitRunnable() {
             int tick = 0;
 
@@ -64,31 +71,31 @@ public final class PortalCreationAnimation {
                 double spiralRotation = tick * 0.25;
                 double wave = Math.sin(progress * Math.PI);
 
-                for (int i = 0; i < pointsPerTick; i++) {
-                    double normalizedIndex = (i + 1) / (double) pointsPerTick;
+                for (int i = 0; i < finalPointsPerTick; i++) {
+                    double normalizedIndex = (i + 1) / (double) finalPointsPerTick;
                     double radiusFactor = Math.sqrt(normalizedIndex) * easing;
                     double angle = GOLDEN_ANGLE * i + spiralRotation;
                     double sin = Math.sin(angle);
                     double cos = Math.cos(angle);
 
-                    double x = cos * radiusFactor * maxRight;
-                    double y = sin * radiusFactor * maxUp;
+                    double x = cos * radiusFactor * finalMaxRight;
+                    double y = sin * radiusFactor * finalMaxUp;
                     double pulse = Math.sin(angle + progress * Math.PI * 2) * 0.03 * wave;
 
-                    Vector offset = right.clone().multiply(x + pulse).add(up.clone().multiply(y - pulse));
+                    Vector offset = finalRight.clone().multiply(x + pulse).add(finalUp.clone().multiply(y - pulse));
                     Location particleLocation = center.clone().add(offset);
                     world.spawnParticle(Particle.DUST, particleLocation.getX(), particleLocation.getY(), particleLocation.getZ(),
-                            1, 0.0, 0.0, 0.0, 0.0, dustOptions);
+                            1, 0.0, 0.0, 0.0, 0.0, finalDustOptions);
                 }
 
                 int outlinePoints = 24;
                 double outlineScale = 0.4 + 0.6 * easing;
                 for (int j = 0; j < outlinePoints; j++) {
                     double theta = (Math.PI * 2 / outlinePoints) * j + spiralRotation * 0.5;
-                    double x = Math.cos(theta) * maxRight * outlineScale;
-                    double y = Math.sin(theta * 0.8 + progress * Math.PI) * maxUp * outlineScale;
+                    double x = Math.cos(theta) * finalMaxRight * outlineScale;
+                    double y = Math.sin(theta * 0.8 + progress * Math.PI) * finalMaxUp * outlineScale;
 
-                    Vector offset = right.clone().multiply(x).add(up.clone().multiply(y));
+                    Vector offset = finalRight.clone().multiply(x).add(finalUp.clone().multiply(y));
                     Location outlineLocation = center.clone().add(offset);
                     world.spawnParticle(Particle.END_ROD, outlineLocation.getX(), outlineLocation.getY(), outlineLocation.getZ(),
                             1, 0.0, 0.0, 0.0, 0.0);

--- a/src/main/java/eu/nurkert/porticlegun/handlers/visualization/TitleHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/visualization/TitleHandler.java
@@ -2,6 +2,7 @@ package eu.nurkert.porticlegun.handlers.visualization;
 
 import eu.nurkert.porticlegun.handlers.item.ItemHandler;
 import eu.nurkert.porticlegun.handlers.portals.ActivePortalsHandler;
+import eu.nurkert.porticlegun.messages.MessageManager;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -10,6 +11,8 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 import org.bukkit.inventory.ItemStack;
+
+import java.util.Map;
 
 public class TitleHandler implements Listener {
 
@@ -62,6 +65,11 @@ public class TitleHandler implements Listener {
         String primary = GunColorHandler.getColors(gunID).getPrimary().getChatColor() + "§o" + (ActivePortalsHandler.hasPrimaryPortal(gunID) ? "§l◀" : "◁");
         String secondary = GunColorHandler.getColors(gunID).getSecondary().getChatColor() + "§o" + (ActivePortalsHandler.hasSecondaryPortal(gunID) ? "§l▶" : "▷");
 
-        player.sendTitle(primary + " " + secondary, "", 0, 20 * 5, 20);
+        String title = MessageManager.getMessage(player, "titles.portal-status", Map.of(
+                "primary", primary,
+                "secondary", secondary
+        ));
+        String subtitle = MessageManager.getMessage(player, "titles.portal-status-subtitle");
+        player.sendTitle(title, subtitle, 0, 20 * 5, 20);
     }
 }

--- a/src/main/java/eu/nurkert/porticlegun/messages/MessageManager.java
+++ b/src/main/java/eu/nurkert/porticlegun/messages/MessageManager.java
@@ -1,0 +1,200 @@
+package eu.nurkert.porticlegun.messages;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Level;
+
+public final class MessageManager {
+
+    private static final Map<UUID, String> PLAYER_LANGUAGES = new HashMap<>();
+    private static FileConfiguration messagesConfig;
+    private static JavaPlugin plugin;
+    private static String defaultLanguage = "en";
+
+    private MessageManager() {
+    }
+
+    public static void init(JavaPlugin javaPlugin) {
+        plugin = javaPlugin;
+        loadMessages();
+    }
+
+    public static void reload(JavaPlugin javaPlugin) {
+        plugin = javaPlugin;
+        loadMessages();
+    }
+
+    private static void loadMessages() {
+        if (plugin == null) {
+            return;
+        }
+
+        if (!plugin.getDataFolder().exists() && !plugin.getDataFolder().mkdirs()) {
+            plugin.getLogger().warning("Could not create plugin data folder for messages.");
+        }
+
+        File file = new File(plugin.getDataFolder(), "messages.yml");
+        if (!file.exists()) {
+            plugin.saveResource("messages.yml", false);
+        }
+
+        messagesConfig = YamlConfiguration.loadConfiguration(file);
+        defaultLanguage = normalizeLanguage(messagesConfig.getString("default-language", "en"));
+        if (!getAvailableLanguages().contains(defaultLanguage)) {
+            Set<String> languages = getAvailableLanguages();
+            if (!languages.isEmpty()) {
+                defaultLanguage = languages.iterator().next();
+                plugin.getLogger().log(Level.WARNING, "Default language missing from messages.yml. Falling back to {0}.", defaultLanguage);
+            }
+        }
+    }
+
+    public static String getMessage(String key) {
+        return getMessage(defaultLanguage, key, Collections.emptyMap());
+    }
+
+    public static String getMessage(String key, Map<String, String> placeholders) {
+        return getMessage(defaultLanguage, key, placeholders);
+    }
+
+    public static String getMessage(CommandSender sender, String key) {
+        return getMessage(sender, key, Collections.emptyMap());
+    }
+
+    public static String getMessage(CommandSender sender, String key, Map<String, String> placeholders) {
+        String language = defaultLanguage;
+        if (sender instanceof Player) {
+            language = resolveLanguage((Player) sender);
+        }
+        return getMessage(language, key, placeholders);
+    }
+
+    public static String getMessage(String language, String key) {
+        return getMessage(language, key, Collections.emptyMap());
+    }
+
+    public static String getMessage(String language, String key, Map<String, String> placeholders) {
+        ensureMessagesLoaded();
+        if (messagesConfig == null) {
+            return ChatColor.RED + "Missing messages.yml";
+        }
+
+        String normalizedLanguage = normalizeLanguage(language);
+        String path = normalizedLanguage + "." + key;
+        String message = messagesConfig.getString(path);
+        if (message == null) {
+            message = messagesConfig.getString(defaultLanguage + "." + key);
+        }
+        if (message == null) {
+            return ChatColor.RED + "Missing message: " + key;
+        }
+
+        if (placeholders != null) {
+            for (Map.Entry<String, String> entry : placeholders.entrySet()) {
+                String placeholderKey = "%" + entry.getKey() + "%";
+                String value = entry.getValue() == null ? "" : entry.getValue();
+                message = message.replace(placeholderKey, value);
+            }
+        }
+
+        return ChatColor.translateAlternateColorCodes('&', message);
+    }
+
+    public static boolean matchesConfiguredValue(String key, String value) {
+        ensureMessagesLoaded();
+        if (messagesConfig == null) {
+            return false;
+        }
+        for (String language : getAvailableLanguages()) {
+            String message = messagesConfig.getString(language + "." + key);
+            if (message != null) {
+                String formatted = ChatColor.translateAlternateColorCodes('&', message);
+                if (formatted.equals(value)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public static void setPlayerLanguage(UUID playerId, String language) {
+        if (language == null) {
+            PLAYER_LANGUAGES.remove(playerId);
+            return;
+        }
+        PLAYER_LANGUAGES.put(playerId, normalizeLanguage(language));
+    }
+
+    public static Optional<String> getPlayerLanguage(UUID playerId) {
+        return Optional.ofNullable(PLAYER_LANGUAGES.get(playerId));
+    }
+
+    public static Set<String> getAvailableLanguages() {
+        ensureMessagesLoaded();
+        if (messagesConfig == null) {
+            return Collections.emptySet();
+        }
+        Set<String> languages = new HashSet<>();
+        for (String key : messagesConfig.getKeys(false)) {
+            if ("default-language".equalsIgnoreCase(key)) {
+                continue;
+            }
+            languages.add(normalizeLanguage(key));
+        }
+        return languages;
+    }
+
+    private static String resolveLanguage(Player player) {
+        UUID playerId = player.getUniqueId();
+        if (PLAYER_LANGUAGES.containsKey(playerId)) {
+            String chosen = PLAYER_LANGUAGES.get(playerId);
+            if (getAvailableLanguages().contains(chosen)) {
+                return chosen;
+            }
+        }
+
+        String locale = player.getLocale();
+        if (locale != null) {
+            String normalizedLocale = normalizeLanguage(locale);
+            if (getAvailableLanguages().contains(normalizedLocale)) {
+                return normalizedLocale;
+            }
+            String[] parts = normalizedLocale.split("[_-]");
+            if (parts.length > 0) {
+                String languageOnly = parts[0];
+                if (getAvailableLanguages().contains(languageOnly)) {
+                    return languageOnly;
+                }
+            }
+        }
+
+        return defaultLanguage;
+    }
+
+    private static String normalizeLanguage(String language) {
+        if (language == null) {
+            return defaultLanguage;
+        }
+        return language.toLowerCase(Locale.ROOT);
+    }
+
+    private static void ensureMessagesLoaded() {
+        if (messagesConfig == null && plugin != null) {
+            loadMessages();
+        }
+    }
+}

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,0 +1,107 @@
+default-language: en
+
+en:
+  commands:
+    general:
+      no-permission: "&cYou do not have permission to use this command."
+      players-only: "&cOnly players may open the PorticleGun menu."
+      unknown: "&cUnknown subcommand. Available: %subcommands%"
+    admin:
+      no-permission: "&cYou do not have permission to manage PorticleGun data."
+    usage:
+      remove: "&cUsage: /%label% remove <gunId>"
+      clearplayer: "&cUsage: /%label% clearplayer <player>"
+    list:
+      empty: "&eNo stored portal guns found."
+      header: "&aStored portal guns (%count%):"
+      entry: "&7- &f%gun_id% &8[&9primary: %primary_status%&8, &dsecondary: %secondary_status%&8]"
+      status:
+        active: "&aactive"
+        saved: "&esaved"
+        none: "&cnone"
+    remove:
+      invalid-id: "&c'%gun_id%' is not a valid PorticleGun ID."
+      success: "&aRemoved stored data for gun &f%gun_id%&a."
+      not-found: "&eNo stored portals were found for gun &f%gun_id%&e."
+    clearplayer:
+      not-online: "&cPlayer '%player%' is not online."
+      none: "&ePlayer &f%player% &ehas no PorticleGuns in their inventories."
+      cleared: "&aCleared portals for &f%player%&a: %gun_ids%"
+      untouched: "&eNo stored portals found for: %gun_ids%"
+      no-change: "&eNo portal data was changed for &f%player%&e."
+      id-format: "&7%gun_id%"
+    reload:
+      success: "&aPorticleGun data reloaded from disk."
+  lists:
+    default-separator: "&8, &7"
+  menus:
+    porticlegun:
+      title: "&8PorticleGun"
+      filler-name: "&0|"
+    settings:
+      title: "&8Settings"
+      reset-name: "&c&lRemove portals"
+      reset-lore: "&8&o(requires double click)"
+      round-label: "&7Round: %state%"
+      round-on: "&2ON"
+      round-off: "&4OFF"
+  items:
+    porticlegun:
+      name: "&5PorticleGun"
+      lore: "&7Device that creates portals."
+  titles:
+    portal-status: "%primary% %secondary%"
+    portal-status-subtitle: ""
+
+de:
+  commands:
+    general:
+      no-permission: "&cDu hast keine Berechtigung, diesen Befehl zu verwenden."
+      players-only: "&cNur Spieler können das PorticleGun-Menü öffnen."
+      unknown: "&cUnbekannter Unterbefehl. Verfügbar: %subcommands%"
+    admin:
+      no-permission: "&cDu hast keine Berechtigung, PorticleGun-Daten zu verwalten."
+    usage:
+      remove: "&cVerwendung: /%label% remove <gunId>"
+      clearplayer: "&cVerwendung: /%label% clearplayer <spieler>"
+    list:
+      empty: "&eKeine gespeicherten Portalwaffen gefunden."
+      header: "&aGespeicherte Portalwaffen (%count%):"
+      entry: "&7- &f%gun_id% &8[&9Primär: %primary_status%&8, &dSekundär: %secondary_status%&8]"
+      status:
+        active: "&aaktiv"
+        saved: "&egespeichert"
+        none: "&ckeine"
+    remove:
+      invalid-id: "&c'%gun_id%' ist keine gültige PorticleGun-ID."
+      success: "&aGespeicherte Daten für Waffe &f%gun_id%&a entfernt."
+      not-found: "&eFür die Waffe &f%gun_id%&e wurden keine gespeicherten Portale gefunden."
+    clearplayer:
+      not-online: "&cSpieler '%player%' ist nicht online."
+      none: "&eSpieler &f%player% &ehat keine PorticleGuns im Inventar."
+      cleared: "&aPortale für &f%player%&a gelöscht: %gun_ids%"
+      untouched: "&eKeine gespeicherten Portale gefunden für: %gun_ids%"
+      no-change: "&eFür &f%player%&e wurden keine Portaldaten geändert."
+      id-format: "&7%gun_id%"
+    reload:
+      success: "&aPorticleGun-Daten von der Festplatte neu geladen."
+  lists:
+    default-separator: "&8, &7"
+  menus:
+    porticlegun:
+      title: "&8PorticleGun"
+      filler-name: "&0|"
+    settings:
+      title: "&8Einstellungen"
+      reset-name: "&c&lPortale entfernen"
+      reset-lore: "&8&o(benötigt Doppelklick)"
+      round-label: "&7Rund: %state%"
+      round-on: "&2AN"
+      round-off: "&4AUS"
+  items:
+    porticlegun:
+      name: "&5PorticleGun"
+      lore: "&7Gerät zum Erstellen von Portalen."
+  titles:
+    portal-status: "%primary% %secondary%"
+    portal-status-subtitle: ""


### PR DESCRIPTION
## Summary
- add a centralized `MessageManager` with default English and German strings in `messages.yml`
- update command, settings, title, and item handlers to read localized messages and per-player menu titles
- document localization workflow and per-player language selection in the README

## Testing
- `mvn -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_68dcfdb8963883229adc134fe55411f4