### PR TITLE
Handle invalid persisted gun IDs gracefully

### DIFF
--- a/src/main/java/eu/nurkert/porticlegun/PorticleGun.java
+++ b/src/main/java/eu/nurkert/porticlegun/PorticleGun.java
@@ -11,7 +11,7 @@ public final class PorticleGun extends JavaPlugin {
     @Override
     public void onEnable() {
         // Plugin startup logic
-        System.out.println("PorticleGun has been enabled!");
+        getLogger().info("PorticleGun has been enabled!");
 
 
         saveDefaultConfig();

--- a/src/main/java/eu/nurkert/porticlegun/commands/PorticleGunCommand.java
+++ b/src/main/java/eu/nurkert/porticlegun/commands/PorticleGunCommand.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.stream.Collectors;
@@ -141,6 +142,10 @@ public class PorticleGunCommand implements CommandExecutor, Listener, TabComplet
                 Map.of("count", String.valueOf(entries.size()))));
         for (String entry : entries) {
             String gunId = ItemHandler.useable(entry);
+            if (gunId == null) {
+                PorticleGun.getInstance().getLogger().warning("Skipping invalid persisted gun id '" + entry + "' while listing porticle guns.");
+                continue;
+            }
             String basePath = "porticleguns." + entry;
             boolean persistedPrimary = PersitentHandler.exists(basePath + ".primary.position");
             boolean persistedSecondary = PersitentHandler.exists(basePath + ".secondary.position");
@@ -313,6 +318,7 @@ public class PorticleGunCommand implements CommandExecutor, Listener, TabComplet
                 String prefix = args[1].toLowerCase(Locale.ROOT);
                 return PersitentHandler.getSection("porticleguns").stream()
                         .map(ItemHandler::useable)
+                        .filter(Objects::nonNull)
                         .filter(id -> id.toLowerCase(Locale.ROOT).startsWith(prefix))
                         .collect(Collectors.toList());
             }

--- a/src/main/java/eu/nurkert/porticlegun/handlers/LoadingHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/LoadingHandler.java
@@ -106,6 +106,10 @@ public class LoadingHandler {
             PersitentHandler.getSection("porticleguns").forEach(porticlegun -> {
                 String basePath = "porticleguns." + porticlegun;
                 String gunID = ItemHandler.useable(porticlegun);
+                if (gunID == null) {
+                    PorticleGun.getInstance().getLogger().warning("Skipping persisted entry '" + porticlegun + "' because it contains invalid characters.");
+                    return;
+                }
                 PortalVisualizationType visualizationType = PortalVisualizationType.fromString(PersitentHandler.get(basePath + ".shape"));
                 if (PersitentHandler.exists(basePath + ".primary")) {
                     PortalColor primaryColor;

--- a/src/main/java/eu/nurkert/porticlegun/handlers/item/ItemHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/item/ItemHandler.java
@@ -1,5 +1,6 @@
 package eu.nurkert.porticlegun.handlers.item;
 
+import eu.nurkert.porticlegun.PorticleGun;
 import eu.nurkert.porticlegun.builders.ItemBuilder;
 import eu.nurkert.porticlegun.messages.MessageManager;
 import org.bukkit.Material;
@@ -54,13 +55,15 @@ public class ItemHandler implements Listener {
     // Charset for generating portal IDs
     private static final String charSet = "ᵃᵇᶜᵈᵉᶠᵍʰᶤʲᵏˡᵐᶰᵒᵖᵠʳˢᵗᵘᵛʷˣʸᶻᴬᴮᶜᴰᴱᶠᴳᴴᴵᴶᴷᴸᴹᴺᴼᴾᵠᴿˢᵀᵁᵛᵂᵡᵞᶻ⁰¹²³⁴⁵⁶⁷⁸⁹";
     private static final String charSet2 = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static final char[] CHAR_SET = charSet.toCharArray();
+    private static final char[] CHAR_SET_ASCII = charSet2.toCharArray();
 
 
 
     public static String generateGunID() {
         StringBuilder id = new StringBuilder();
         for (int i = 0; i < 10; i++) {
-            id.append(charSet.toCharArray()[new Random().nextInt(charSet.length())]);
+            id.append(CHAR_SET[new Random().nextInt(CHAR_SET.length)]);
         }
         return id.toString();
     }
@@ -110,15 +113,31 @@ public class ItemHandler implements Listener {
     public static String saveable(String id) {
         StringBuilder encoded = new StringBuilder();
         for (char c : id.toCharArray()) {
-            encoded.append(charSet2.toCharArray()[charSet.indexOf(c)]);
+            int index = charSet.indexOf(c);
+            if (index == -1) {
+                PorticleGun.getInstance().getLogger().warning("Encountered unknown character '" + c + "' while encoding gun id");
+                continue;
+            }
+            encoded.append(CHAR_SET_ASCII[index]);
         }
         return encoded.toString();
     }
 
+    /**
+     * Decodes an id stored in the configuration.
+     *
+     * @param id the persisted id encoded via {@link #saveable(String)}
+     * @return the decoded id or {@code null} if the persisted value contains unsupported characters
+     */
     public static String useable(String id) {
         StringBuilder decoded = new StringBuilder();
         for (char c : id.toCharArray()) {
-            decoded.append(charSet.toCharArray()[charSet2.indexOf(c)]);
+            int index = charSet2.indexOf(c);
+            if (index == -1) {
+                PorticleGun.getInstance().getLogger().warning("Encountered unknown character '" + c + "' while decoding gun id");
+                return null;
+            }
+            decoded.append(CHAR_SET[index]);
         }
         return decoded.toString();
     }


### PR DESCRIPTION
## Summary
- avoid using System.out and log plugin startup through the plugin logger
- guard against invalid persisted gun ids while loading data and when listing or completing commands
- make the item id encoder/decoder resilient to unexpected characters and reuse cached character arrays

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dd04a3cbf48322b9ea7856fc752081