### PR TITLE
Replace legacy block data access in gravity gun

### DIFF
--- a/src/main/java/eu/nurkert/porticlegun/handlers/gravity/GravityGun.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/gravity/GravityGun.java
@@ -149,8 +149,8 @@ public class GravityGun implements Listener {
                                         }
 
 					AudioHandler.playSound(player.getLocation(), AudioHandler.PortalSound.GRAB_BLOCK);
-					FallingBlock fallingblock = (FallingBlock) block.getLocation().getWorld()
-							.spawnFallingBlock(block.getLocation().add(0.5, 0, 0.5), block.getType(), block.getData());
+                                        FallingBlock fallingblock = (FallingBlock) block.getLocation().getWorld()
+                                                        .spawnFallingBlock(block.getLocation().add(0.5, 0, 0.5), block.getBlockData());
 
 					if (block.getType() == Material.SPAWNER) {
 //						spawner.put(player.getUniqueId().toString(),


### PR DESCRIPTION
## Summary
- replace legacy block data usage in the gravity gun with modern BlockData to avoid expensive legacy conversions

## Testing
- mvn -q package

------
https://chatgpt.com/codex/tasks/task_e_68dd07b71eac83228bb227e107774e8f