### PR TITLE
Fix portal orientation transform

### DIFF
--- a/src/main/java/eu/nurkert/porticlegun/handlers/portals/TeleportationHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/portals/TeleportationHandler.java
@@ -70,6 +70,8 @@ public class TeleportationHandler implements Listener {
         double upComponent = vector.dot(source.up);
         double rightComponent = vector.dot(source.right);
 
+        forwardComponent *= -1;
+
         Vector transformed = destination.forward.clone().multiply(forwardComponent);
         transformed.add(destination.up.clone().multiply(upComponent));
         transformed.add(destination.right.clone().multiply(rightComponent));


### PR DESCRIPTION
## Summary
- invert the forward component when transforming player look direction and velocity between linked portals to preserve orientation when teleporting

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dd09aa0d5083229862a3dc154ce193