### PR TITLE
Fix portal basis orientation for consistent lateral movement

### DIFF
--- a/src/main/java/eu/nurkert/porticlegun/handlers/portals/TeleportationHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/portals/TeleportationHandler.java
@@ -53,14 +53,14 @@ public class TeleportationHandler implements Listener {
         forward.normalize();
 
         Vector auxiliaryAxis = Math.abs(forward.getY()) > 0.999 ? new Vector(0, 0, 1) : new Vector(0, 1, 0);
-        Vector right = forward.clone().crossProduct(auxiliaryAxis);
+        Vector right = auxiliaryAxis.clone().crossProduct(forward);
         if (right.lengthSquared() == 0) {
             auxiliaryAxis = new Vector(1, 0, 0);
-            right = forward.clone().crossProduct(auxiliaryAxis);
+            right = auxiliaryAxis.clone().crossProduct(forward);
         }
         right.normalize();
 
-        Vector up = right.clone().crossProduct(forward).normalize();
+        Vector up = forward.clone().crossProduct(right).normalize();
 
         return new PortalBasis(forward, up, right);
     }


### PR DESCRIPTION
## Summary
- compute the portal basis right vector using a consistent cross-product order
- ensure the portal basis remains right-handed so lateral momentum is preserved when exiting portals

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd0d02e3b08322b3767e166261af17