### PR TITLE
Fix lateral velocity mirroring through portals

### DIFF
--- a/src/main/java/eu/nurkert/porticlegun/handlers/portals/TeleportationHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/portals/TeleportationHandler.java
@@ -71,6 +71,7 @@ public class TeleportationHandler implements Listener {
         double rightComponent = vector.dot(source.right);
 
         forwardComponent *= -1;
+        rightComponent *= -1;
 
         Vector transformed = destination.forward.clone().multiply(forwardComponent);
         transformed.add(destination.up.clone().multiply(upComponent));


### PR DESCRIPTION
## Summary
- correct the teleportation vector transform so strafing maintains its direction after portal traversal

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68dd11e03e1c83228343c492bec0d64c