### PR TITLE
Add Geyser detection to adjust portal placement for Bedrock players

### DIFF
--- a/src/main/java/eu/nurkert/porticlegun/handlers/compat/GeyserCompatibility.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/compat/GeyserCompatibility.java
@@ -1,0 +1,117 @@
+package eu.nurkert.porticlegun.handlers.compat;
+
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.UUID;
+
+/**
+ * Utility class that detects whether a player joined through Geyser/Floodgate
+ * without requiring the dependencies at compile time.
+ */
+public final class GeyserCompatibility {
+
+    private static final boolean FLOODGATE_AVAILABLE;
+    private static final Object FLOODGATE_API_INSTANCE;
+    private static final Method FLOODGATE_IS_PLAYER_METHOD;
+
+    private static final boolean GEYSER_API_AVAILABLE;
+    private static final Object GEYSER_API_INSTANCE;
+    private static final Method GEYSER_CONNECTION_BY_UUID_METHOD;
+
+    static {
+        FLOODGATE_API_INSTANCE = loadFloodgateApiInstance();
+        FLOODGATE_IS_PLAYER_METHOD = loadFloodgateIsPlayerMethod(FLOODGATE_API_INSTANCE);
+        FLOODGATE_AVAILABLE = FLOODGATE_API_INSTANCE != null && FLOODGATE_IS_PLAYER_METHOD != null;
+
+        GEYSER_API_INSTANCE = loadGeyserApiInstance();
+        GEYSER_CONNECTION_BY_UUID_METHOD = loadGeyserConnectionByUuidMethod(GEYSER_API_INSTANCE);
+        GEYSER_API_AVAILABLE = GEYSER_API_INSTANCE != null && GEYSER_CONNECTION_BY_UUID_METHOD != null;
+    }
+
+    private GeyserCompatibility() {
+    }
+
+    public static boolean isBedrockPlayer(Player player) {
+        if (player == null) {
+            return false;
+        }
+
+        UUID uuid = player.getUniqueId();
+
+        if (FLOODGATE_AVAILABLE) {
+            try {
+                Object result = FLOODGATE_IS_PLAYER_METHOD.invoke(FLOODGATE_API_INSTANCE, uuid);
+                if (result instanceof Boolean && (Boolean) result) {
+                    return true;
+                }
+            } catch (IllegalAccessException | InvocationTargetException ignored) {
+            }
+        }
+
+        if (GEYSER_API_AVAILABLE) {
+            try {
+                Object connection = GEYSER_CONNECTION_BY_UUID_METHOD.invoke(GEYSER_API_INSTANCE, uuid);
+                if (connection != null) {
+                    return true;
+                }
+            } catch (IllegalAccessException | InvocationTargetException ignored) {
+            }
+        }
+
+        return false;
+    }
+
+    private static Object loadFloodgateApiInstance() {
+        try {
+            Class<?> floodgateApiClass = Class.forName("org.geysermc.floodgate.api.FloodgateApi");
+            Method getInstance = floodgateApiClass.getMethod("getInstance");
+            return getInstance.invoke(null);
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException ignored) {
+            return null;
+        }
+    }
+
+    private static Method loadFloodgateIsPlayerMethod(Object apiInstance) {
+        if (apiInstance == null) {
+            return null;
+        }
+
+        try {
+            Class<?> floodgateApiClass = apiInstance.getClass();
+            return floodgateApiClass.getMethod("isFloodgatePlayer", UUID.class);
+        } catch (NoSuchMethodException ignored) {
+            return null;
+        }
+    }
+
+    private static Object loadGeyserApiInstance() {
+        try {
+            Class<?> geyserApiClass = Class.forName("org.geysermc.geyser.api.GeyserApi");
+            Method apiMethod = geyserApiClass.getMethod("api");
+            return apiMethod.invoke(null);
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException ignored) {
+            return null;
+        }
+    }
+
+    private static Method loadGeyserConnectionByUuidMethod(Object apiInstance) {
+        if (apiInstance == null) {
+            return null;
+        }
+
+        try {
+            return apiInstance.getClass().getMethod("connectionByUuid", UUID.class);
+        } catch (NoSuchMethodException ignored) {
+            for (Class<?> iface : apiInstance.getClass().getInterfaces()) {
+                try {
+                    return iface.getMethod("connectionByUuid", UUID.class);
+                } catch (NoSuchMethodException ignoredAgain) {
+                    // continue searching
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/eu/nurkert/porticlegun/handlers/portals/PortalOpenHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/portals/PortalOpenHandler.java
@@ -2,6 +2,7 @@ package eu.nurkert.porticlegun.handlers.portals;
 
 import eu.nurkert.porticlegun.handlers.AudioHandler;
 import eu.nurkert.porticlegun.handlers.PersitentHandler;
+import eu.nurkert.porticlegun.handlers.compat.GeyserCompatibility;
 import eu.nurkert.porticlegun.handlers.item.ItemHandler;
 import eu.nurkert.porticlegun.handlers.visualization.PortalCreationAnimation;
 import eu.nurkert.porticlegun.handlers.visualization.TitleHandler;
@@ -39,18 +40,19 @@ public class PortalOpenHandler implements Listener {
                         if(!playersHight.getBlock().getType().isSolid()) {
                             Action action = event.getAction();
 
-                            if(action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK) {
+                            Portal.PortalType targetType = determinePortalType(action, player);
+                            if (targetType != null) {
                                 PortalVisualizationType visualizationType = PortalVisualizationType.fromString(PersitentHandler.get("porticleguns." + ItemHandler.saveable(gunID) + ".shape"));
-                                Portal primary = new Portal(potential, gunID, Portal.PortalType.PRIMARY, visualizationType);
-                                ActivePortalsHandler.setPrimaryPortal(gunID, primary);
-                                primary.saveAll();
-                                PortalCreationAnimation.play(primary);
-                            } else if(action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK) {
-                                PortalVisualizationType visualizationType = PortalVisualizationType.fromString(PersitentHandler.get("porticleguns." + ItemHandler.saveable(gunID) + ".shape"));
-                                Portal secondary = new Portal(potential, gunID, Portal.PortalType.SECONDARY, visualizationType);
-                                ActivePortalsHandler.setSecondaryPortal(gunID, secondary);
-                                secondary.saveAll();
-                                PortalCreationAnimation.play(secondary);
+                                Portal portal = new Portal(potential, gunID, targetType, visualizationType);
+
+                                if (targetType == Portal.PortalType.PRIMARY) {
+                                    ActivePortalsHandler.setPrimaryPortal(gunID, portal);
+                                } else {
+                                    ActivePortalsHandler.setSecondaryPortal(gunID, portal);
+                                }
+
+                                portal.saveAll();
+                                PortalCreationAnimation.play(portal);
                             }
                             TitleHandler.sendPortalStatus(player, gunID);
                             AudioHandler.playSound(player, AudioHandler.PortalSound.PORTAL_OPEN);
@@ -95,5 +97,19 @@ public class PortalOpenHandler implements Listener {
         }
 
         return true;
+    }
+
+    private Portal.PortalType determinePortalType(Action action, Player player) {
+        boolean bedrockPlayer = GeyserCompatibility.isBedrockPlayer(player);
+
+        if (action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK) {
+            return bedrockPlayer ? Portal.PortalType.SECONDARY : Portal.PortalType.PRIMARY;
+        }
+
+        if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK) {
+            return bedrockPlayer ? Portal.PortalType.PRIMARY : Portal.PortalType.SECONDARY;
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- add a compatibility helper that detects Bedrock players via Floodgate or Geyser APIs when available
- swap portal placement handling for Geyser players so their primary and secondary portals align with controller buttons

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dd160b26e08322a19ef3d49d59475c