### PR TITLE
Add quick rename option for plugin jar

### DIFF
--- a/src/main/java/eu/nurkert/porticlegun/commands/PorticleGunCommand.java
+++ b/src/main/java/eu/nurkert/porticlegun/commands/PorticleGunCommand.java
@@ -8,6 +8,8 @@ import eu.nurkert.porticlegun.handlers.item.ItemHandler;
 import eu.nurkert.porticlegun.handlers.portals.ActivePortalsHandler;
 import eu.nurkert.porticlegun.messages.MessageManager;
 import eu.nurkert.porticlegun.portals.Portal;
+import eu.nurkert.porticlegun.util.PluginJarRenamer;
+import eu.nurkert.porticlegun.util.PluginJarRenamer.RenameResult;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.command.Command;
@@ -39,6 +41,7 @@ public class PorticleGunCommand implements CommandExecutor, Listener, TabComplet
 
     private static final String COMMAND_PERMISSION = "porticlegun.command";
     private static final String ADMIN_PERMISSION = "porticlegun.admin";
+    private static final int QUICK_RENAME_SLOT = 0;
     private static final List<String> ADMIN_SUBCOMMANDS = Arrays.asList("list", "remove", "clearplayer", "reload");
 
     public PorticleGunCommand() {
@@ -102,17 +105,64 @@ public class PorticleGunCommand implements CommandExecutor, Listener, TabComplet
     private Inventory createMenu(Player player) {
         Inventory inventory = Bukkit.createInventory(null, InventoryType.DROPPER,
                 MessageManager.getMessage(player, "menus.porticlegun.title"));
-        ItemStack filler = new ItemBuilder(Material.BLACK_STAINED_GLASS_PANE)
-                .setName(MessageManager.getMessage(player, "menus.porticlegun.filler-name"))
-                .build();
+        ItemStack filler = createFiller(player);
         for (int i = 0; i < inventory.getSize(); i++) {
             if (i == 4) {
                 continue;
             }
             inventory.setItem(i, filler.clone());
         }
+        ItemStack renameItem = createQuickRenameItem(player);
+        if (renameItem != null) {
+            inventory.setItem(QUICK_RENAME_SLOT, renameItem);
+        }
         inventory.setItem(4, ItemHandler.generateNewGun());
         return inventory;
+    }
+
+    private ItemStack createFiller(Player player) {
+        return new ItemBuilder(Material.BLACK_STAINED_GLASS_PANE)
+                .setName(MessageManager.getMessage(player, "menus.porticlegun.filler-name"))
+                .build();
+    }
+
+    private ItemStack createQuickRenameItem(Player player) {
+        if (!player.hasPermission(ADMIN_PERMISSION)) {
+            return null;
+        }
+        if (!PluginJarRenamer.isRenameAvailable(PorticleGun.getInstance())) {
+            return null;
+        }
+
+        String target = PluginJarRenamer.getTargetFileName(PorticleGun.getInstance());
+        String name = MessageManager.getMessage(player, "menus.porticlegun.rename-jar-name",
+                Map.of("target", target));
+        String loreRaw = MessageManager.getMessage(player, "menus.porticlegun.rename-jar-lore",
+                Map.of("target", target));
+
+        ItemBuilder builder = new ItemBuilder(Material.NAME_TAG)
+                .setName(name);
+        String[] lore = splitLore(loreRaw);
+        if (lore.length > 0) {
+            builder.setLore(lore);
+        }
+        return builder.build();
+    }
+
+    private String[] splitLore(String loreRaw) {
+        if (loreRaw == null || loreRaw.isEmpty()) {
+            return new String[0];
+        }
+        return loreRaw.split("\n");
+    }
+
+    private void updateRenameSlot(Inventory inventory, Player player) {
+        ItemStack renameItem = createQuickRenameItem(player);
+        if (renameItem != null) {
+            inventory.setItem(QUICK_RENAME_SLOT, renameItem);
+        } else {
+            inventory.setItem(QUICK_RENAME_SLOT, createFiller(player));
+        }
     }
 
     private boolean ensureAdmin(CommandSender sender) {
@@ -345,8 +395,44 @@ public class PorticleGunCommand implements CommandExecutor, Listener, TabComplet
                 event.setCancelled(true);
                 if (event.getRawSlot() == 4) {
                     event.setCursor(ItemHandler.generateNewGun());
+                } else if (event.getRawSlot() == QUICK_RENAME_SLOT && event.getWhoClicked() instanceof Player) {
+                    handleQuickRename((Player) event.getWhoClicked(), event.getInventory());
                 }
             }
+        }
+    }
+
+    private void handleQuickRename(Player player, Inventory inventory) {
+        if (!player.hasPermission(ADMIN_PERMISSION)) {
+            player.sendMessage(MessageManager.getMessage(player, "commands.admin.no-permission"));
+            return;
+        }
+
+        PorticleGun plugin = PorticleGun.getInstance();
+        String target = PluginJarRenamer.getTargetFileName(plugin);
+        Map<String, String> placeholders = Map.of("target", target);
+        RenameResult result = PluginJarRenamer.renameToDataFolder(plugin);
+
+        switch (result) {
+            case SUCCESS:
+                player.sendMessage(MessageManager.getMessage(player, "menus.porticlegun.rename-jar-success", placeholders));
+                player.closeInventory();
+                break;
+            case ALREADY_MATCHED:
+                player.sendMessage(MessageManager.getMessage(player, "menus.porticlegun.rename-jar-already", placeholders));
+                updateRenameSlot(inventory, player);
+                break;
+            case CONFLICT:
+                player.sendMessage(MessageManager.getMessage(player, "menus.porticlegun.rename-jar-conflict", placeholders));
+                break;
+            case UNAVAILABLE:
+                player.sendMessage(MessageManager.getMessage(player, "menus.porticlegun.rename-jar-unavailable"));
+                updateRenameSlot(inventory, player);
+                break;
+            case ERROR:
+            default:
+                player.sendMessage(MessageManager.getMessage(player, "menus.porticlegun.rename-jar-error"));
+                break;
         }
     }
 

--- a/src/main/java/eu/nurkert/porticlegun/util/PluginJarRenamer.java
+++ b/src/main/java/eu/nurkert/porticlegun/util/PluginJarRenamer.java
@@ -1,0 +1,106 @@
+package eu.nurkert.porticlegun.util;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.security.CodeSource;
+import java.util.Optional;
+import java.util.logging.Level;
+
+/**
+ * Utility methods for working with the plugin's jar file.
+ */
+public final class PluginJarRenamer {
+
+    private PluginJarRenamer() {
+    }
+
+    public enum RenameResult {
+        SUCCESS,
+        ALREADY_MATCHED,
+        CONFLICT,
+        UNAVAILABLE,
+        ERROR
+    }
+
+    private static Optional<Path> resolvePluginJar(JavaPlugin plugin) {
+        if (plugin == null) {
+            return Optional.empty();
+        }
+
+        try {
+            CodeSource source = plugin.getClass().getProtectionDomain().getCodeSource();
+            if (source == null) {
+                return Optional.empty();
+            }
+            URL location = source.getLocation();
+            if (location == null) {
+                return Optional.empty();
+            }
+            Path path = Paths.get(location.toURI());
+            if (!Files.isRegularFile(path)) {
+                return Optional.empty();
+            }
+            return Optional.of(path);
+        } catch (URISyntaxException | IllegalArgumentException ex) {
+            plugin.getLogger().log(Level.WARNING, "Unable to resolve plugin jar location.", ex);
+            return Optional.empty();
+        }
+    }
+
+    public static boolean isRenameAvailable(JavaPlugin plugin) {
+        Optional<Path> current = resolvePluginJar(plugin);
+        if (current.isEmpty()) {
+            return false;
+        }
+        Path desired = current.get().resolveSibling(getTargetFileName(plugin));
+        return !current.get().getFileName().equals(desired.getFileName());
+    }
+
+    public static String getTargetFileName(JavaPlugin plugin) {
+        String folderName = plugin.getDataFolder().getName();
+        return folderName + ".jar";
+    }
+
+    public static Optional<String> getCurrentFileName(JavaPlugin plugin) {
+        return resolvePluginJar(plugin).map(path -> path.getFileName().toString());
+    }
+
+    public static RenameResult renameToDataFolder(JavaPlugin plugin) {
+        Optional<Path> currentPath = resolvePluginJar(plugin);
+        if (currentPath.isEmpty()) {
+            return RenameResult.UNAVAILABLE;
+        }
+
+        Path current = currentPath.get();
+        Path target = current.resolveSibling(getTargetFileName(plugin));
+
+        if (current.getFileName().equals(target.getFileName())) {
+            return RenameResult.ALREADY_MATCHED;
+        }
+
+        if (Files.exists(target)) {
+            return RenameResult.CONFLICT;
+        }
+
+        try {
+            try {
+                Files.move(current, target, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException ignored) {
+                Files.move(current, target);
+            }
+            return RenameResult.SUCCESS;
+        } catch (IOException ex) {
+            plugin.getLogger().log(Level.WARNING, "Failed to rename plugin jar.", ex);
+            return RenameResult.ERROR;
+        }
+    }
+}
+

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -38,6 +38,13 @@ en:
     porticlegun:
       title: "&8PorticleGun"
       filler-name: "&0|"
+      rename-jar-name: "&bRename plugin jar"
+      rename-jar-lore: "&7Click to rename the jar to &f%target%&7.\n&8Requires file system access."
+      rename-jar-success: "&aRenamed plugin jar to &f%target%&a."
+      rename-jar-already: "&eThe plugin jar already matches the data folder name."
+      rename-jar-conflict: "&cAnother file named &f%target% &calready exists. Remove or rename it first."
+      rename-jar-error: "&cCould not rename the plugin jar. Check the console for details."
+      rename-jar-unavailable: "&cThe plugin jar location could not be determined while running from this environment."
     settings:
       title: "&8Settings"
       reset-name: "&c&lRemove portals"
@@ -91,6 +98,13 @@ de:
     porticlegun:
       title: "&8PorticleGun"
       filler-name: "&0|"
+      rename-jar-name: "&bPlugin-Jar umbenennen"
+      rename-jar-lore: "&7Klicke, um die Jar in &f%target%&7 umzubenennen.\n&8Benötigt Dateisystem-Zugriff."
+      rename-jar-success: "&aPlugin-Jar in &f%target% &aumbenannt."
+      rename-jar-already: "&eDie Plugin-Jar heißt bereits wie der Datenordner."
+      rename-jar-conflict: "&cEine Datei namens &f%target% &cist bereits vorhanden. Bitte zuerst entfernen oder umbenennen."
+      rename-jar-error: "&cDie Plugin-Jar konnte nicht umbenannt werden. Siehe Konsole für Details."
+      rename-jar-unavailable: "&cDer Speicherort der Plugin-Jar konnte in dieser Umgebung nicht ermittelt werden."
     settings:
       title: "&8Einstellungen"
       reset-name: "&c&lPortale entfernen"


### PR DESCRIPTION
## Summary
- add a quick rename action to the PorticleGun menu so admins can align the jar name with the data folder in one click
- implement a PluginJarRenamer utility that resolves the running jar and performs guarded rename operations
- localize the new menu item and status feedback in both English and German

## Testing
- mvn -DskipTests package *(fails: remote dependency download stalled in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deca51a84883228716315cf325de19