### PR TITLE
Add optional WorldGuard integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,10 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
+        <repository>
+            <id>enginehub</id>
+            <url>https://maven.enginehub.org/repo/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -83,6 +87,13 @@
             <artifactId>spigot-api</artifactId>
             <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-bukkit</artifactId>
+            <version>7.0.8</version>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/src/main/java/eu/nurkert/porticlegun/PorticleGun.java
+++ b/src/main/java/eu/nurkert/porticlegun/PorticleGun.java
@@ -4,6 +4,7 @@ import eu.nurkert.porticlegun.config.ConfigManager;
 import eu.nurkert.porticlegun.handlers.LoadingHandler;
 import eu.nurkert.porticlegun.handlers.PersitentHandler;
 import eu.nurkert.porticlegun.messages.MessageManager;
+import eu.nurkert.porticlegun.util.WorldGuardIntegration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class PorticleGun extends JavaPlugin {
@@ -19,10 +20,22 @@ public final class PorticleGun extends JavaPlugin {
         PersitentHandler.getInstance();
         MessageManager.init(this);
         LoadingHandler.getInstance();
+        worldGuardEnabled = false;
+        try {
+            Class.forName("com.sk89q.worldguard.WorldGuard");
+            WorldGuardIntegration.init(this);
+            worldGuardEnabled = WorldGuardIntegration.isEnabled();
+            if (!worldGuardEnabled) {
+                getLogger().info("WorldGuard detected but integration could not be enabled.");
+            }
+        } catch (ClassNotFoundException | NoClassDefFoundError exception) {
+            getLogger().info("WorldGuard classes not found - integration disabled.");
+        }
     }
 
     public static boolean developMode = false;
     static PorticleGun plugin;
+    private boolean worldGuardEnabled;
 
     public PorticleGun() {
         plugin = this;
@@ -30,5 +43,9 @@ public final class PorticleGun extends JavaPlugin {
 
     public static PorticleGun getInstance() {
         return plugin;
+    }
+
+    public static boolean isWorldGuardEnabled() {
+        return plugin != null && plugin.worldGuardEnabled;
     }
 }

--- a/src/main/java/eu/nurkert/porticlegun/handlers/gravity/GravityGun.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/gravity/GravityGun.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import eu.nurkert.porticlegun.PorticleGun;
 import eu.nurkert.porticlegun.handlers.AudioHandler;
 import eu.nurkert.porticlegun.handlers.item.ItemHandler;
+import eu.nurkert.porticlegun.util.WorldGuardIntegration;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -217,11 +218,21 @@ public class GravityGun implements Listener {
                                                 }
 
                                                 if (entity.getLocation().distance(loc) < 1.5) {
+                                                        if (PorticleGun.isWorldGuardEnabled()
+                                                                        && !WorldGuardIntegration.canUseGravityGun(player, entity.getLocation())) {
+                                                                continue;
+                                                        }
                                                         entitys.put(entity, playersLook(player));
                                                         players.put(player, entity);
                                                         AudioHandler.playSound(player.getLocation(), AudioHandler.PortalSound.GRAB_BLOCK);
                                                         return;
                                                 }
+                                        }
+
+                                        if (PorticleGun.isWorldGuardEnabled()
+                                                        && !WorldGuardIntegration.canUseGravityGun(player, block.getLocation())) {
+                                                AudioHandler.playSound(event.getPlayer(), AudioHandler.PortalSound.DENY);
+                                                return;
                                         }
 
                                         if (blacklist.contains(block.getType()) || block.isLiquid()) {

--- a/src/main/java/eu/nurkert/porticlegun/handlers/portals/PortalOpenHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/portals/PortalOpenHandler.java
@@ -1,5 +1,6 @@
 package eu.nurkert.porticlegun.handlers.portals;
 
+import eu.nurkert.porticlegun.PorticleGun;
 import eu.nurkert.porticlegun.handlers.AudioHandler;
 import eu.nurkert.porticlegun.handlers.PersitentHandler;
 import eu.nurkert.porticlegun.handlers.item.ItemHandler;
@@ -9,6 +10,7 @@ import eu.nurkert.porticlegun.handlers.visualization.concrete.PortalVisualizatio
 import eu.nurkert.porticlegun.portals.Portal;
 import eu.nurkert.porticlegun.portals.PortalTracing;
 import eu.nurkert.porticlegun.portals.PotentialPortal;
+import eu.nurkert.porticlegun.util.WorldGuardIntegration;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -37,6 +39,10 @@ public class PortalOpenHandler implements Listener {
                         // so player can stand where he wants to place portal
                         Location playersHight = potential.getLocation().clone().add(0, potential.getDirection().getY() != 0.0 ? potential.getDirection().getY() : 1, 0);
                         if(!playersHight.getBlock().getType().isSolid()) {
+                            if (PorticleGun.isWorldGuardEnabled() && !WorldGuardIntegration.canCreatePortal(player, potential.getLocation(), potential.getDirection())) {
+                                AudioHandler.playSound(player, AudioHandler.PortalSound.DENY);
+                                return;
+                            }
                             Action action = event.getAction();
 
                             if(action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK) {

--- a/src/main/java/eu/nurkert/porticlegun/handlers/portals/TeleportationHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/portals/TeleportationHandler.java
@@ -3,6 +3,7 @@ package eu.nurkert.porticlegun.handlers.portals;
 import eu.nurkert.porticlegun.PorticleGun;
 import eu.nurkert.porticlegun.handlers.gravity.GravityGun;
 import eu.nurkert.porticlegun.portals.Portal;
+import eu.nurkert.porticlegun.util.WorldGuardIntegration;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
@@ -132,6 +133,11 @@ public class TeleportationHandler implements Listener {
 
         Portal linkedPortal = portal.getLinkedPortal();
         if (linkedPortal == null || linkedPortal.getLocation().getWorld() == null) {
+            return false;
+        }
+
+        if (PorticleGun.isWorldGuardEnabled()
+                && !WorldGuardIntegration.canUsePortal(entity, portal.getLocation(), linkedPortal.getLocation())) {
             return false;
         }
 

--- a/src/main/java/eu/nurkert/porticlegun/util/WorldGuardIntegration.java
+++ b/src/main/java/eu/nurkert/porticlegun/util/WorldGuardIntegration.java
@@ -1,0 +1,142 @@
+package eu.nurkert.porticlegun.util;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.flags.Flag;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
+import com.sk89q.worldguard.protection.regions.RegionContainer;
+import com.sk89q.worldguard.protection.regions.RegionQuery;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.Vector;
+
+import java.util.logging.Level;
+
+public final class WorldGuardIntegration {
+
+    private static boolean enabled;
+    private static WorldGuardPlugin worldGuardPlugin;
+    private static RegionContainer regionContainer;
+    private static StateFlag portalCreateFlag;
+    private static StateFlag portalUseFlag;
+    private static StateFlag gravityGunFlag;
+
+    private WorldGuardIntegration() {
+    }
+
+    public static void init(JavaPlugin plugin) {
+        Plugin wgPlugin = Bukkit.getPluginManager().getPlugin("WorldGuard");
+        if (!(wgPlugin instanceof WorldGuardPlugin wg) || !wgPlugin.isEnabled()) {
+            plugin.getLogger().log(Level.INFO, "WorldGuard not present - skipping integration.");
+            return;
+        }
+
+        try {
+            FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();
+            portalCreateFlag = registerStateFlag(registry, "porticlegun-portal-create", true);
+            portalUseFlag = registerStateFlag(registry, "porticlegun-portal-use", true);
+            gravityGunFlag = registerStateFlag(registry, "porticlegun-gravity-gun", true);
+
+            worldGuardPlugin = wg;
+            regionContainer = WorldGuard.getInstance().getPlatform().getRegionContainer();
+            enabled = true;
+
+            plugin.getLogger().log(Level.INFO, "Enabled WorldGuard support with PorticleGun flags.");
+        } catch (FlagConflictException conflict) {
+            plugin.getLogger().log(Level.WARNING, "A conflicting WorldGuard flag prevented PorticleGun integration: {0}",
+                    conflict.getMessage());
+        } catch (Throwable throwable) {
+            plugin.getLogger().log(Level.WARNING, "Failed to initialise WorldGuard integration", throwable);
+        }
+    }
+
+    public static boolean isEnabled() {
+        return enabled;
+    }
+
+    public static boolean canCreatePortal(Player player, Location baseLocation, Vector direction) {
+        if (!enabled) {
+            return true;
+        }
+
+        if (player == null || baseLocation == null) {
+            return false;
+        }
+
+        LocalPlayer localPlayer = worldGuardPlugin.wrapPlayer(player);
+        if (!testFlag(localPlayer, baseLocation, portalCreateFlag)) {
+            return false;
+        }
+
+        if (direction == null) {
+            return true;
+        }
+
+        Location upper = baseLocation.clone().add(0, 1, 0);
+        if (Math.abs(direction.getY()) < 0.5 && !testFlag(localPlayer, upper, portalCreateFlag)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static boolean canUsePortal(Entity entity, Location source, Location destination) {
+        if (!enabled) {
+            return true;
+        }
+
+        LocalPlayer localPlayer = entity instanceof Player ? worldGuardPlugin.wrapPlayer((Player) entity) : null;
+        return testFlag(localPlayer, source, portalUseFlag) && testFlag(localPlayer, destination, portalUseFlag);
+    }
+
+    public static boolean canUseGravityGun(Player player, Location location) {
+        if (!enabled) {
+            return true;
+        }
+
+        if (player == null) {
+            return false;
+        }
+
+        return testFlag(worldGuardPlugin.wrapPlayer(player), location, gravityGunFlag);
+    }
+
+    private static StateFlag registerStateFlag(FlagRegistry registry, String name, boolean defaultValue)
+            throws FlagConflictException {
+        StateFlag flag = new StateFlag(name, defaultValue);
+        try {
+            registry.register(flag);
+            return flag;
+        } catch (FlagConflictException conflict) {
+            Flag<?> existing = registry.get(name);
+            if (existing instanceof StateFlag) {
+                return (StateFlag) existing;
+            }
+            throw conflict;
+        }
+    }
+
+    private static boolean testFlag(LocalPlayer localPlayer, Location location, StateFlag flag) {
+        if (flag == null || location == null || location.getWorld() == null) {
+            return true;
+        }
+
+        if (regionContainer == null) {
+            return true;
+        }
+
+        RegionQuery query = regionContainer.createQuery();
+        com.sk89q.worldedit.util.Location adapted = BukkitAdapter.adapt(location);
+        ApplicableRegionSet set = query.getApplicableRegions(adapted);
+        return set.testState(localPlayer, flag);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ version: v1.2.2-SNAPSHOT
 main: eu.nurkert.porticlegun.PorticleGun
 api-version: 1.19
 authors: [ nurkert ]
+softdepend: [WorldGuard]
 
 commands:
   porticlegun:


### PR DESCRIPTION
## Summary
- add an optional WorldGuard integration layer with custom flags that gate portal creation, portal use, and gravity gun interactions
- call the integration from portal and gravity handlers only when WorldGuard is available so the plugin continues to run without it
- declare the WorldGuard soft-depend entry and dependency metadata needed to compile against its API

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e2fa7bc08c832289167557df8370c7