### PR TITLE
Add portal shot animation before opening portals

### DIFF
--- a/src/main/java/eu/nurkert/porticlegun/handlers/portals/PortalOpenHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/portals/PortalOpenHandler.java
@@ -4,7 +4,10 @@ import eu.nurkert.porticlegun.PorticleGun;
 import eu.nurkert.porticlegun.handlers.AudioHandler;
 import eu.nurkert.porticlegun.handlers.PersitentHandler;
 import eu.nurkert.porticlegun.handlers.item.ItemHandler;
+import eu.nurkert.porticlegun.handlers.visualization.GunColorHandler;
+import eu.nurkert.porticlegun.handlers.visualization.PortalColor;
 import eu.nurkert.porticlegun.handlers.visualization.PortalCreationAnimation;
+import eu.nurkert.porticlegun.handlers.visualization.PortalShotAnimation;
 import eu.nurkert.porticlegun.handlers.visualization.TitleHandler;
 import eu.nurkert.porticlegun.handlers.visualization.concrete.PortalVisualizationType;
 import eu.nurkert.porticlegun.portals.Portal;
@@ -20,53 +23,38 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.util.Vector;
 
 public class PortalOpenHandler implements Listener {
 
     @EventHandler
     public void on(PlayerInteractEvent event) {
         // check if it is possible to place portal
-        if(event.getItem() != null && !event.getPlayer().isSneaking()) {
-            // check if player is holding a gun
-            String gunID = ItemHandler.isValidGun(event.getItem());
-            if(gunID != null) {
-                Player player = event.getPlayer();
-                PotentialPortal potential = PortalTracing.tracePortal(player);
-                // check if a potential portal was found
-                if(potential != null && hasRequiredBackingBlocks(potential)) {
-                    // check if the portal is not placed in a solid block
-                    if(!potential.getLocation().getBlock().getType().isSolid()) {
-                        // so player can stand where he wants to place portal
-                        Location playersHight = potential.getLocation().clone().add(0, potential.getDirection().getY() != 0.0 ? potential.getDirection().getY() : 1, 0);
-                        if(!playersHight.getBlock().getType().isSolid()) {
-                            if (PorticleGun.isWorldGuardEnabled() && !WorldGuardIntegration.canCreatePortal(player, potential.getLocation(), potential.getDirection())) {
-                                AudioHandler.playSound(player, AudioHandler.PortalSound.DENY);
-                                return;
-                            }
-                            Action action = event.getAction();
-
-                            if(action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK) {
-                                PortalVisualizationType visualizationType = PortalVisualizationType.fromString(PersitentHandler.get("porticleguns." + ItemHandler.saveable(gunID) + ".shape"));
-                                Portal primary = new Portal(potential, gunID, Portal.PortalType.PRIMARY, visualizationType);
-                                ActivePortalsHandler.setPrimaryPortal(gunID, primary);
-                                primary.saveAll();
-                                PortalCreationAnimation.play(primary);
-                            } else if(action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK) {
-                                PortalVisualizationType visualizationType = PortalVisualizationType.fromString(PersitentHandler.get("porticleguns." + ItemHandler.saveable(gunID) + ".shape"));
-                                Portal secondary = new Portal(potential, gunID, Portal.PortalType.SECONDARY, visualizationType);
-                                ActivePortalsHandler.setSecondaryPortal(gunID, secondary);
-                                secondary.saveAll();
-                                PortalCreationAnimation.play(secondary);
-                            }
-                            TitleHandler.sendPortalStatus(player, gunID);
-                            AudioHandler.playSound(player, AudioHandler.PortalSound.PORTAL_OPEN);
-                            return;
-                        }
-                    }
-                }
-                AudioHandler.playSound(player, AudioHandler.PortalSound.DENY);
-            }
+        if(event.getItem() == null || event.getPlayer().isSneaking()) {
+            return;
         }
+
+        String gunID = ItemHandler.isValidGun(event.getItem());
+        if(gunID == null) {
+            return;
+        }
+
+        Action action = event.getAction();
+        if(action != Action.LEFT_CLICK_AIR && action != Action.LEFT_CLICK_BLOCK
+                && action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        PotentialPortal traced = PortalTracing.tracePortal(player);
+        PotentialPortal snapshot = clonePotential(traced);
+
+        Portal.PortalType type = (action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK)
+                ? Portal.PortalType.PRIMARY : Portal.PortalType.SECONDARY;
+        PortalColor color = GunColorHandler.getColors(gunID).get(type);
+
+        PortalShotAnimation.play(player, snapshot, color, () ->
+                attemptPortalPlacement(player, gunID, type, snapshot));
     }
 
 
@@ -100,6 +88,66 @@ public class PortalOpenHandler implements Listener {
             }
         }
 
+        return true;
+    }
+
+    private PotentialPortal clonePotential(PotentialPortal potential) {
+        if (potential == null) {
+            return null;
+        }
+
+        Location location = potential.getLocation().clone();
+        Vector direction = potential.getDirection() != null
+                ? potential.getDirection().clone()
+                : location.getDirection().clone();
+        return new PotentialPortal(location, direction);
+    }
+
+    private boolean attemptPortalPlacement(Player player, String gunID, Portal.PortalType type, PotentialPortal potential) {
+        if (player == null || !player.isOnline()) {
+            return false;
+        }
+
+        if (potential == null) {
+            AudioHandler.playSound(player, AudioHandler.PortalSound.DENY);
+            return false;
+        }
+
+        if (!hasRequiredBackingBlocks(potential)) {
+            AudioHandler.playSound(player, AudioHandler.PortalSound.DENY);
+            return false;
+        }
+
+        if (potential.getLocation().getBlock().getType().isSolid()) {
+            AudioHandler.playSound(player, AudioHandler.PortalSound.DENY);
+            return false;
+        }
+
+        Location playersHight = potential.getLocation().clone().add(0,
+                potential.getDirection().getY() != 0.0 ? potential.getDirection().getY() : 1, 0);
+        if (playersHight.getBlock().getType().isSolid()) {
+            AudioHandler.playSound(player, AudioHandler.PortalSound.DENY);
+            return false;
+        }
+
+        if (PorticleGun.isWorldGuardEnabled()
+                && !WorldGuardIntegration.canCreatePortal(player, potential.getLocation(), potential.getDirection())) {
+            AudioHandler.playSound(player, AudioHandler.PortalSound.DENY);
+            return false;
+        }
+
+        PortalVisualizationType visualizationType = PortalVisualizationType.fromString(
+                PersitentHandler.get("porticleguns." + ItemHandler.saveable(gunID) + ".shape"));
+        Portal portal = new Portal(potential, gunID, type, visualizationType);
+        if (type == Portal.PortalType.PRIMARY) {
+            ActivePortalsHandler.setPrimaryPortal(gunID, portal);
+        } else {
+            ActivePortalsHandler.setSecondaryPortal(gunID, portal);
+        }
+        portal.saveAll();
+        PortalCreationAnimation.play(portal);
+        TitleHandler.sendPortalStatus(player, gunID);
+        AudioHandler.playSound(player, AudioHandler.PortalSound.PORTAL_OPEN);
         return true;
     }
 }

--- a/src/main/java/eu/nurkert/porticlegun/handlers/visualization/PortalCreationAnimation.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/visualization/PortalCreationAnimation.java
@@ -3,6 +3,7 @@ package eu.nurkert.porticlegun.handlers.visualization;
 import eu.nurkert.porticlegun.PorticleGun;
 import eu.nurkert.porticlegun.handlers.portals.ActivePortalsHandler;
 import eu.nurkert.porticlegun.handlers.visualization.GunColorHandler;
+import eu.nurkert.porticlegun.handlers.visualization.PortalGeometry;
 import eu.nurkert.porticlegun.portals.Portal;
 import eu.nurkert.porticlegun.handlers.visualization.concrete.PortalVisualizationType;
 import org.bukkit.Color;
@@ -27,7 +28,7 @@ public final class PortalCreationAnimation {
             return;
         }
 
-        final Location center = computePortalCenter(portal);
+        final Location center = PortalGeometry.computePortalCenter(portal);
         if (center == null) {
             return;
         }
@@ -200,19 +201,6 @@ public final class PortalCreationAnimation {
                 (random.nextDouble() - 0.5) * spreadUp,
                 (random.nextDouble() - 0.5) * spreadRight,
                 0.1);
-    }
-
-    private static Location computePortalCenter(Portal portal) {
-        Location base = portal.getLocation().clone();
-        Vector direction = portal.getDirection();
-        if (direction.getY() == 0.0) {
-            return base.add(0.5 - 0.4 * direction.getX(), 1.0, 0.5 - 0.4 * direction.getZ());
-        } else if (direction.getY() < 0.0) {
-            return base.add(0.5, 0.9, 0.5);
-        } else if (direction.getY() > 0.0) {
-            return base.add(0.5, 0.1, 0.5);
-        }
-        return base;
     }
 
     private static boolean isPortalStillActive(Portal portal) {

--- a/src/main/java/eu/nurkert/porticlegun/handlers/visualization/PortalGeometry.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/visualization/PortalGeometry.java
@@ -1,0 +1,35 @@
+package eu.nurkert.porticlegun.handlers.visualization;
+
+import eu.nurkert.porticlegun.portals.Portal;
+import eu.nurkert.porticlegun.portals.PotentialPortal;
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+
+/**
+ * Shared helper for portal positioning calculations.
+ */
+public final class PortalGeometry {
+
+    private PortalGeometry() {
+    }
+
+    public static Location computePortalCenter(Portal portal) {
+        return computePortalCenter(portal.getLocation(), portal.getDirection());
+    }
+
+    public static Location computePortalCenter(PotentialPortal portal) {
+        return computePortalCenter(portal.getLocation(), portal.getDirection());
+    }
+
+    public static Location computePortalCenter(Location base, Vector direction) {
+        Location center = base.clone();
+        if (direction.getY() == 0.0) {
+            return center.add(0.5 - 0.4 * direction.getX(), 1.0, 0.5 - 0.4 * direction.getZ());
+        } else if (direction.getY() < 0.0) {
+            return center.add(0.5, 0.9, 0.5);
+        } else if (direction.getY() > 0.0) {
+            return center.add(0.5, 0.1, 0.5);
+        }
+        return center;
+    }
+}

--- a/src/main/java/eu/nurkert/porticlegun/handlers/visualization/PortalShotAnimation.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/visualization/PortalShotAnimation.java
@@ -1,0 +1,142 @@
+package eu.nurkert.porticlegun.handlers.visualization;
+
+import eu.nurkert.porticlegun.PorticleGun;
+import eu.nurkert.porticlegun.config.ConfigManager;
+import eu.nurkert.porticlegun.portals.PotentialPortal;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+
+import java.util.function.BooleanSupplier;
+
+public final class PortalShotAnimation {
+
+    private static final double STEP_DISTANCE = 0.6;
+    private static final double SWIRL_RADIUS = 0.35;
+    private static final double IMPACT_RADIUS = 0.55;
+
+    private PortalShotAnimation() {
+    }
+
+    public static void play(Player player, PotentialPortal potentialTarget, PortalColor color,
+                            BooleanSupplier onImpact) {
+        if (player == null) {
+            return;
+        }
+
+        Location start = player.getEyeLocation();
+        World world = start.getWorld();
+        if (world == null) {
+            if (onImpact != null) {
+                onImpact.getAsBoolean();
+            }
+            return;
+        }
+
+        Vector forward = start.getDirection().clone();
+        if (forward.lengthSquared() == 0.0) {
+            forward = new Vector(0, 0, 1);
+        }
+        forward.normalize();
+
+        Location impactPoint;
+        double travelDistance;
+        if (potentialTarget != null) {
+            impactPoint = PortalGeometry.computePortalCenter(potentialTarget);
+            travelDistance = start.distance(impactPoint);
+        } else {
+            double maxDistance = ConfigManager.getPortalMaxTargetDistance();
+            impactPoint = start.clone().add(forward.clone().multiply(maxDistance));
+            travelDistance = maxDistance;
+        }
+
+        if (travelDistance < 0.1) {
+            travelDistance = 0.1;
+        }
+
+        Vector right = computeRightVector(forward);
+        Vector up = forward.clone().crossProduct(right).normalize();
+        Vector step = forward.clone().multiply(STEP_DISTANCE);
+        int totalSteps = Math.max(1, (int) Math.ceil(travelDistance / STEP_DISTANCE));
+        Particle.DustOptions dustOptions = color.getDustOptions();
+
+        new BukkitRunnable() {
+            int currentStep = 0;
+            final Location current = start.clone();
+
+            @Override
+            public void run() {
+                if (!player.isOnline() || player.getWorld() != world) {
+                    cancel();
+                    return;
+                }
+
+                double progress = currentStep / (double) totalSteps;
+                spawnTrail(world, current, right, up, dustOptions, progress);
+
+                current.add(step);
+                currentStep++;
+                if (currentStep >= totalSteps) {
+                    boolean success = onImpact != null && onImpact.getAsBoolean();
+                    spawnImpact(world, impactPoint, right, up, dustOptions, success);
+                    cancel();
+                }
+            }
+        }.runTaskTimer(PorticleGun.getInstance(), 0L, 1L);
+    }
+
+    private static void spawnTrail(World world, Location point, Vector right, Vector up,
+                                   Particle.DustOptions dustOptions, double progress) {
+        double swirlTurns = 5.0;
+        double baseAngle = swirlTurns * Math.PI * 2 * progress;
+
+        for (int arm = 0; arm < 2; arm++) {
+            double angle = baseAngle + arm * Math.PI;
+            Vector offset = right.clone().multiply(Math.cos(angle) * SWIRL_RADIUS)
+                    .add(up.clone().multiply(Math.sin(angle) * SWIRL_RADIUS));
+            Location swirl = point.clone().add(offset);
+            world.spawnParticle(Particle.DUST, swirl, 1, 0.0, 0.0, 0.0, 0.0, dustOptions);
+        }
+
+        world.spawnParticle(Particle.CRIT, point.getX(), point.getY(), point.getZ(), 2, 0.0, 0.0, 0.0, 0.0);
+    }
+
+    private static void spawnImpact(World world, Location impactPoint, Vector right, Vector up,
+                                    Particle.DustOptions dustOptions, boolean success) {
+        if (impactPoint == null) {
+            return;
+        }
+
+        double sparks = success ? 24 : 12;
+        for (int i = 0; i < sparks; i++) {
+            double angle = (Math.PI * 2 / sparks) * i;
+            Vector offset = right.clone().multiply(Math.cos(angle) * IMPACT_RADIUS)
+                    .add(up.clone().multiply(Math.sin(angle) * IMPACT_RADIUS));
+            Location particleLocation = impactPoint.clone().add(offset);
+            if (success) {
+                world.spawnParticle(Particle.END_ROD, particleLocation, 1, 0.0, 0.0, 0.0, 0.0);
+            } else {
+                world.spawnParticle(Particle.CLOUD, particleLocation, 1, 0.0, 0.0, 0.0, 0.01);
+            }
+        }
+
+        if (success) {
+            world.spawnParticle(Particle.PORTAL, impactPoint, 30, 0.25, 0.25, 0.25, 0.05);
+        } else {
+            world.spawnParticle(Particle.CRIT, impactPoint, 16, 0.25, 0.25, 0.25, 0.15);
+        }
+    }
+
+    private static Vector computeRightVector(Vector forward) {
+        Vector reference = Math.abs(forward.getY()) < 0.95 ? new Vector(0, 1, 0) : new Vector(1, 0, 0);
+        Vector right = reference.clone().crossProduct(forward);
+        if (right.lengthSquared() == 0.0) {
+            right = new Vector(1, 0, 0);
+        }
+        right.normalize();
+        return right;
+    }
+}


### PR DESCRIPTION
## Summary
- delay opening sounds and portal placement until the projectile animation reaches the target block
- add a spiral particle shot animation with impact variations for successful and failed portal creation
- extract portal center calculation into a reusable helper shared by the shot and creation animations

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e2fe5896a483229f2dd1bbe9805175