### PR TITLE
Prevent portal placement when activating gravity gun without target

### DIFF
--- a/src/main/java/eu/nurkert/porticlegun/handlers/gravity/GravityGun.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/gravity/GravityGun.java
@@ -200,7 +200,12 @@ public class GravityGun implements Listener {
 					players.get(player).setFallDistance(0F);
 					players.remove(player);
 				} else {
-					Block block = player.getTargetBlock((HashSet<Material>) null, 4);
+                                        Block block = player.getTargetBlockExact(4);
+
+                                        if (block == null || block.getType() == Material.AIR) {
+                                                AudioHandler.playSound(player, AudioHandler.PortalSound.DENY);
+                                                return;
+                                        }
 
 					Location loc = playersLook(player);
 


### PR DESCRIPTION
## Summary
- ensure the gravity gun only targets solid blocks by using `getTargetBlockExact`
- abort activation when no block is targeted to avoid accidental portal placement

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e3194ef3d08322b0a7f1993bf5056d