### PR TITLE
Allow gravity gun to move chests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ All three flags default to `ALLOW`, so existing regions continue to work unchang
 
 * `gravity-gun.enabled` – Set to `false` to completely disable the gravity gun event listeners and background tasks.
 * `gravity-gun.block-blacklist` – A list of Bukkit material names that players are prevented from picking up with the gravity gun.
+* `gravity-gun.allow-chest-capture` – Controls whether the gravity gun may pick up chests even if they appear in legacy configuration files.
 
 ## Localization
 

--- a/src/main/java/eu/nurkert/porticlegun/config/ConfigManager.java
+++ b/src/main/java/eu/nurkert/porticlegun/config/ConfigManager.java
@@ -17,8 +17,9 @@ public final class ConfigManager {
     private static final int DEFAULT_MAX_BLOCK_TRACE = 100;
     private static final boolean DEFAULT_GRAVITY_GUN_ENABLED = true;
     private static final boolean DEFAULT_GRAVITY_GUN_ALLOW_PLAYER_CAPTURE = false;
+    private static final boolean DEFAULT_GRAVITY_GUN_ALLOW_CHEST_CAPTURE = true;
     private static final Set<Material> DEFAULT_GRAVITY_GUN_BLOCK_BLACKLIST =
-            Collections.unmodifiableSet(EnumSet.of(Material.AIR, Material.CHEST));
+            Collections.unmodifiableSet(EnumSet.of(Material.AIR));
 
     private static int maxTargetDistance = DEFAULT_MAX_TARGET_DISTANCE;
     private static int maxPlayerDistance = DEFAULT_MAX_PLAYER_DISTANCE;
@@ -46,14 +47,18 @@ public final class ConfigManager {
         maxBlockTrace = ensurePositive(config.getInt("portal.max-block-trace", DEFAULT_MAX_BLOCK_TRACE), DEFAULT_MAX_BLOCK_TRACE);
         gravityGunEnabled = config.getBoolean("gravity-gun.enabled", DEFAULT_GRAVITY_GUN_ENABLED);
         gravityGunAllowPlayerCapture = config.getBoolean("gravity-gun.allow-player-capture", DEFAULT_GRAVITY_GUN_ALLOW_PLAYER_CAPTURE);
-        loadGravityGunBlacklist(config.getStringList("gravity-gun.block-blacklist"));
+        boolean allowChestCapture = config.getBoolean("gravity-gun.allow-chest-capture", DEFAULT_GRAVITY_GUN_ALLOW_CHEST_CAPTURE);
+        loadGravityGunBlacklist(config.getStringList("gravity-gun.block-blacklist"), allowChestCapture);
     }
 
-    private static void loadGravityGunBlacklist(Collection<String> configuredEntries) {
+    private static void loadGravityGunBlacklist(Collection<String> configuredEntries, boolean allowChestCapture) {
         gravityGunBlockBlacklist.clear();
 
         if (configuredEntries == null || configuredEntries.isEmpty()) {
             gravityGunBlockBlacklist.addAll(DEFAULT_GRAVITY_GUN_BLOCK_BLACKLIST);
+            if (!allowChestCapture) {
+                gravityGunBlockBlacklist.add(Material.CHEST);
+            }
             return;
         }
 
@@ -72,6 +77,12 @@ public final class ConfigManager {
 
         if (gravityGunBlockBlacklist.isEmpty()) {
             gravityGunBlockBlacklist.addAll(DEFAULT_GRAVITY_GUN_BLOCK_BLACKLIST);
+        }
+
+        if (allowChestCapture) {
+            gravityGunBlockBlacklist.remove(Material.CHEST);
+        } else {
+            gravityGunBlockBlacklist.add(Material.CHEST);
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,6 +12,6 @@
 gravity-gun:
   enabled: true
   allow-player-capture: false
+  allow-chest-capture: true
   block-blacklist:
     - AIR
-    - CHEST


### PR DESCRIPTION
## Summary
- allow the gravity gun to pick up chests by default while keeping a configurable escape hatch
- update the default configuration template and documentation for the new chest capture option

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e31b5afecc83229a230abc949b26f2