### PR TITLE
Delay portal ring animation until creation finishes

### DIFF
--- a/src/main/java/eu/nurkert/porticlegun/handlers/visualization/PortalCreationAnimation.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/visualization/PortalCreationAnimation.java
@@ -17,7 +17,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public final class PortalCreationAnimation {
 
-    private static final int ANIMATION_DURATION_TICKS = 30;
+    public static final int ANIMATION_DURATION_TICKS = 30;
     private static final double GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
 
     private PortalCreationAnimation() {
@@ -36,6 +36,8 @@ public final class PortalCreationAnimation {
         if (world == null) {
             return;
         }
+
+        portal.delayVisualizationByTicks(ANIMATION_DURATION_TICKS);
 
         Vector normal = portal.getDirection().clone().normalize();
         Vector reference = Math.abs(normal.getY()) < 0.99 ? new Vector(0, 1, 0) : new Vector(1, 0, 0);

--- a/src/main/java/eu/nurkert/porticlegun/handlers/visualization/PortalShotAnimation.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/visualization/PortalShotAnimation.java
@@ -110,15 +110,13 @@ public final class PortalShotAnimation {
             return;
         }
 
-        double sparks = success ? 24 : 12;
-        for (int i = 0; i < sparks; i++) {
-            double angle = (Math.PI * 2 / sparks) * i;
-            Vector offset = right.clone().multiply(Math.cos(angle) * IMPACT_RADIUS)
-                    .add(up.clone().multiply(Math.sin(angle) * IMPACT_RADIUS));
-            Location particleLocation = impactPoint.clone().add(offset);
-            if (success) {
-                world.spawnParticle(Particle.END_ROD, particleLocation, 1, 0.0, 0.0, 0.0, 0.0);
-            } else {
+        if (!success) {
+            int sparks = 12;
+            for (int i = 0; i < sparks; i++) {
+                double angle = (Math.PI * 2 / sparks) * i;
+                Vector offset = right.clone().multiply(Math.cos(angle) * IMPACT_RADIUS)
+                        .add(up.clone().multiply(Math.sin(angle) * IMPACT_RADIUS));
+                Location particleLocation = impactPoint.clone().add(offset);
                 world.spawnParticle(Particle.CLOUD, particleLocation, 1, 0.0, 0.0, 0.0, 0.01);
             }
         }

--- a/src/main/java/eu/nurkert/porticlegun/handlers/visualization/VisualizationHanlder.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/visualization/VisualizationHanlder.java
@@ -26,6 +26,9 @@ public class VisualizationHanlder implements Listener {
                 ArrayList<Portal> portals = ActivePortalsHandler.getAllPortal();
                 for (int i = 0; i < portals.size(); i++) {
                     Portal portal = portals.get(i);
+                    if (!portal.isVisualizationReady()) {
+                        continue;
+                    }
                     double radians = Math.toRadians(System.currentTimeMillis() / 5);
                     Vector[] locs = {portal.getParticleLocation(radians) , portal.getParticleLocation(radians + Math.PI)};
                     Color color = GunColorHandler.getColors(portal.getGunID()).get(portal.getType()).getBukkitColor();

--- a/src/main/java/eu/nurkert/porticlegun/portals/Portal.java
+++ b/src/main/java/eu/nurkert/porticlegun/portals/Portal.java
@@ -21,12 +21,15 @@ public class Portal extends PotentialPortal {
 
     PortalVisualizationType visualizationType;
 
+    private long visualizationResumeTimeMillis;
+
     public Portal(Location location, Vector direction, String gunID, PortalType type, PortalVisualizationType visualizationType) {
         super(location, direction);
         this.gunID = gunID;
         this.linkedPortal = null;
         this.type = type;
         this.visualizationType = visualizationType;
+        this.visualizationResumeTimeMillis = 0L;
     }
 
     public Portal(PotentialPortal potential, String gunID, PortalType type, PortalVisualizationType visualizationType) {
@@ -35,6 +38,7 @@ public class Portal extends PotentialPortal {
         this.type = type;
         this.linkedPortal = null;
         this.visualizationType = visualizationType;
+        this.visualizationResumeTimeMillis = 0L;
     }
 
     public Portal(String position, String gunID, PortalType type, PortalVisualizationType visualizationType) {
@@ -43,6 +47,7 @@ public class Portal extends PotentialPortal {
         this.type = type;
         this.linkedPortal = null;
         this.visualizationType = visualizationType;
+        this.visualizationResumeTimeMillis = 0L;
     }
 
     private static Location extractLocation(String from) {
@@ -79,6 +84,18 @@ public class Portal extends PotentialPortal {
     public PortalVisualizationType toggleVisualizationType() {
         this.visualizationType = this.visualizationType.getNext();
         return this.visualizationType;
+    }
+
+    public void delayVisualizationByTicks(int ticks) {
+        if (ticks <= 0) {
+            this.visualizationResumeTimeMillis = 0L;
+            return;
+        }
+        this.visualizationResumeTimeMillis = System.currentTimeMillis() + ticks * 50L;
+    }
+
+    public boolean isVisualizationReady() {
+        return System.currentTimeMillis() >= this.visualizationResumeTimeMillis;
     }
 
     /**


### PR DESCRIPTION
## Summary
- remove the white end-rod circle from the successful portal impact animation
- delay the standard portal ring visualization until the creation particle growth completes
- track visualization readiness on each portal to coordinate animation timing

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e409bcecc88322a6ed6954d469bbd1