### PR TITLE
Gate teleportation behind active portal visualization

### DIFF
--- a/src/main/java/eu/nurkert/porticlegun/handlers/portals/TeleportationHandler.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/portals/TeleportationHandler.java
@@ -53,6 +53,10 @@ public class TeleportationHandler implements Listener {
         Player player = event.getPlayer();
         ArrayList<Portal> portals = ActivePortalsHandler.getRelevantPortals(player);
         for (Portal portal : portals) {
+            if (!isPortalVisualizationActive(portal) || !isPortalVisualizationActive(portal.getLinkedPortal())) {
+                clearPortalLockIfMatches(player, portal);
+                continue;
+            }
             boolean inPortal = isEntityInPortal(portal, event.getTo());
             if (inPortal) {
                 if (isPortalLocked(player, portal)) {
@@ -72,6 +76,9 @@ public class TeleportationHandler implements Listener {
         cleanupCooldowns();
 
         for (Portal portal : ActivePortalsHandler.getAllPortal()) {
+            if (!isPortalVisualizationActive(portal) || !isPortalVisualizationActive(portal.getLinkedPortal())) {
+                continue;
+            }
             Portal linked = portal.getLinkedPortal();
             if (linked == null) {
                 continue;
@@ -132,7 +139,7 @@ public class TeleportationHandler implements Listener {
         }
 
         Portal linkedPortal = portal.getLinkedPortal();
-        if (linkedPortal == null || linkedPortal.getLocation().getWorld() == null) {
+        if (!isPortalVisualizationActive(portal) || !isPortalVisualizationActive(linkedPortal)) {
             return false;
         }
 
@@ -212,7 +219,7 @@ public class TeleportationHandler implements Listener {
     }
 
     private boolean isEntityInPortal(Portal portal, Location location) {
-        if (location == null) {
+        if (!isPortalVisualizationActive(portal) || location == null) {
             return false;
         }
 
@@ -226,6 +233,19 @@ public class TeleportationHandler implements Listener {
         }
 
         return false;
+    }
+
+    private boolean isPortalVisualizationActive(Portal portal) {
+        if (portal == null) {
+            return false;
+        }
+
+        if (!portal.isVisualizationReady()) {
+            return false;
+        }
+
+        Location location = portal.getLocation();
+        return location != null && location.getWorld() != null;
     }
 
     static PortalBasis createPortalBasis(Vector direction) {

--- a/src/main/java/eu/nurkert/porticlegun/handlers/visualization/VisualizationHanlder.java
+++ b/src/main/java/eu/nurkert/porticlegun/handlers/visualization/VisualizationHanlder.java
@@ -4,7 +4,6 @@ import eu.nurkert.porticlegun.PorticleGun;
 import eu.nurkert.porticlegun.handlers.portals.ActivePortalsHandler;
 import eu.nurkert.porticlegun.portals.Portal;
 import org.bukkit.*;
-import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
@@ -29,19 +28,25 @@ public class VisualizationHanlder implements Listener {
                     if (!portal.isVisualizationReady()) {
                         continue;
                     }
-                    double radians = Math.toRadians(System.currentTimeMillis() / 5);
-                    Vector[] locs = {portal.getParticleLocation(radians) , portal.getParticleLocation(radians + Math.PI)};
-                    Color color = GunColorHandler.getColors(portal.getGunID()).get(portal.getType()).getBukkitColor();
-                    for(Player player : Bukkit.getOnlinePlayers()) {
-                        Particle.DustOptions dustOptions = new Particle.DustOptions(color, 1);
-                        for(Vector loc : locs) {
-                            player.spawnParticle(Particle.DUST, loc.getX(), loc.getY(), loc.getZ(), 1, dustOptions);
-                        }
-                        //player.getWorld().spawnParticle(Particle.NOTE, player.getLocation(), 1, null);
 
-
+                    Location portalLocation = portal.getLocation();
+                    if (portalLocation == null) {
+                        continue;
                     }
 
+                    World world = portalLocation.getWorld();
+                    if (world == null) {
+                        continue;
+                    }
+
+                    double radians = Math.toRadians(System.currentTimeMillis() / 5);
+                    Vector[] locs = {portal.getParticleLocation(radians), portal.getParticleLocation(radians + Math.PI)};
+                    Color color = GunColorHandler.getColors(portal.getGunID()).get(portal.getType()).getBukkitColor();
+                    Particle.DustOptions dustOptions = new Particle.DustOptions(color, 1);
+                    for (Vector loc : locs) {
+                        Location particleLocation = new Location(world, loc.getX(), loc.getY(), loc.getZ());
+                        world.spawnParticle(Particle.DUST, particleLocation, 1, 0.0, 0.0, 0.0, 0.0, dustOptions);
+                    }
                 }
             }
         }.runTaskTimer(PorticleGun.getInstance(), 0, 1);

--- a/src/main/java/eu/nurkert/porticlegun/portals/PotentialPortal.java
+++ b/src/main/java/eu/nurkert/porticlegun/portals/PotentialPortal.java
@@ -22,10 +22,21 @@ public class PotentialPortal {
     }
 
     public boolean isInPortal(Location loc) {
-        if (loc == null) {
+        if (loc == null || loc.getWorld() == null) {
             return false; // or handle the null case appropriately
         }
-        return this.location.getBlockX() == loc.getBlockX() && this.location.getBlockY() == loc.getBlockY() && this.location.getBlockZ() == loc.getBlockZ();
+
+        if (this.location == null || this.location.getWorld() == null) {
+            return false;
+        }
+
+        if (!this.location.getWorld().equals(loc.getWorld())) {
+            return false;
+        }
+
+        return this.location.getBlockX() == loc.getBlockX()
+                && this.location.getBlockY() == loc.getBlockY()
+                && this.location.getBlockZ() == loc.getBlockZ();
     }
 
     public void setLocation(Location location) {


### PR DESCRIPTION
## Summary
- skip portal interactions unless both portals are actively visualized in their worlds
- guard teleport execution behind the same visualization checks to avoid linking to inactive portals

## Testing
- mvn -B -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68fe3e239e1c8322bc0e6523443eeed6